### PR TITLE
Add bind install

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -12,6 +12,7 @@ wptagent currently supports Windows and Linux hosts (possibly OSX but not tested
     * ujson
     * websocket-client
     * xvfbwrapper (Linux only)
+    * bind9utils (Linux only)
 * Imagemagick installed and available in the path
     * The legacy tools (convert, compare, etc) need to be installed which may be optional on Windows
 * ffmpeg installed and available in the path

--- a/ubuntu_install.sh
+++ b/ubuntu_install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo apt-get install -y python-pip imagemagick ffmpeg xvfb
+sudo apt-get install -y python-pip imagemagick ffmpeg xvfb bind9utils
 sudo pip install dnspython monotonic pillow psutil requests ujson websocket-client xvfbwrapper
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' 


### PR DESCRIPTION
While running the agent saw an error indicating that `rndc` is not installed. Adding its installation to the docs and related script.