### PR TITLE
Use host-resolver-rules instead of host-rules

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -52,7 +52,7 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
         host_rules = HOST_RULES
         if 'host_rules' in task:
             host_rules.extend(task['host_rules'])
-        args.append('--host-rules=' + ','.join(host_rules))
+        args.append('--host-resolver-rules=' + ','.join(host_rules))
         args.extend(['--window-position="0,0"',
                      '--window-size="{0:d},{1:d}"'.format(task['width'], task['height'])])
         args.append('--remote-debugging-port={0:d}'.format(task['port']))


### PR DESCRIPTION
According to https://bugs.chromium.org/p/chromium/issues/detail?id=704545#c5 we should be using host-resolver-rules in order to avoid cert verification issues when using MITMed certs. So now we are :)

I ran into this issue when running a setup with MITMProxy, and this change solved the issues I encountered.