### PR TITLE
Support for traffic shaping in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && \
     kmod \
     ffmpeg \
     net-tools \
-    tcpdump
+    tcpdump \
+    bind9utils
 
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
   wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -44,8 +45,8 @@ RUN pip install \
 
 COPY wptagent.py /wptagent/wptagent.py
 COPY internal /wptagent/internal
+COPY ws4py /wptagent/ws4py
 COPY docker/linux-headless/entrypoint.sh /wptagent/entrypoint.sh
-COPY docker/linux-headless/browsers.ini /wptagent/browsers.ini
 
 WORKDIR /wptagent
 

--- a/README.md
+++ b/README.md
@@ -98,3 +98,7 @@ Cross-platform WebPageTest agent (currently supports Chrome only on Windows and 
     * waitForJSDone (change semantics to console log message)
     * overrideHost (depends on support being added to dev tools)
     * if/else/endif
+
+## Run with docker
+Check out [the docker instructions](docs/install.md) for information on how to
+run the agent in a docker container.

--- a/docker/linux-headless/entrypoint.sh
+++ b/docker/linux-headless/entrypoint.sh
@@ -17,4 +17,4 @@ if [ -n "$NAME" ]; then
   EXTRA_ARGS="$EXTRA_ARGS --name $NAME"
 fi
 
-python /wptagent/wptagent.py --server $SERVER_URL --location $LOCATION $EXTRA_ARGS --xvfb --dockerized -vvvvv --shaper none
+python /wptagent/wptagent.py --server $SERVER_URL --location $LOCATION $EXTRA_ARGS --xvfb --dockerized -vvvvv

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -6,17 +6,28 @@ To run the agent, simply specify a few environment variables with docker:
 * `LOCATION` will be passed as `--location`
 * `NAME` will be passed as `--name` (optional)
 
+## Prerequisites to use traffic shaping in docker
+**Experimental**: Running the agent with traffic shaping is experimental. It might
+have influence on the host system network. Running multiple agents on the
+same host might result in incorrect traffic shaping.
+
+For traffic shaping to work correctly, you need to load the ifb module on the **host**:
+
+    sudo modprobe ifb numifbs=1
+
+Also, the container needs `NET_ADMIN` capabilities, so run the container with 
+`--cap-add=NET_ADMIN`.
+
 ## Example
 
-Build the image first (from project root), and start it
+Build the image first (from project root), load ifb and start it the container:
 
     sudo docker build --tag wptagent .
+    sudo modprobe ifb numifbs=1
     sudo docker run -d \
       -e SERVER_URL="http://my-wpt-server.org/work/" \
       -e LOCATION="docker-location" \
       -e NAME="Docker Test" \
+      --cap-add=NET_ADMIN
       wptagent
 
-
-## Known issues
-* Traffic shaping does not yet work

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,6 +11,7 @@ wptagent currently supports Windows and Linux hosts (possibly OSX but not tested
     * requests
     * ujson
     * xvfbwrapper (Linux only)
+    * bind9utils (Linux only, for rndc)
 * Imagemagick installed and available in the path
     * The legacy tools (convert, compare, etc) need to be installed which may be optional on Windows
 * ffmpeg installed and available in the path


### PR DESCRIPTION
As stated in [docs/docker.md](docs/docker.md), the container is finally able to do traffic shaping with a few prerequisites.

I'm not quite sure if this affects the host system or other containers, since I'm not sure how much of the network is virtualized by docker and what's really shared.

I slightly modified `NetEm` when dockerized, so it does not attempt to load `ifb` via modprobe, but adds the `ifb0` interface (was necessary in my test scenario).