### PR TITLE
[don't merge] fix: pass blocked URLs to Lighthouse 

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -365,6 +365,8 @@ class DevtoolsBrowser(object):
                 command.append('--save-assets')
             if self.options.android or 'mobile' not in self.job or not self.job['mobile']:
                 command.append('--disable-device-emulation')
+            if len(task['block']):
+                command.extend(['--blocked-url-patterns=%s' % url for url in task['block']])
             command.append('"{0}"'.format(self.job['url']))
             cmd = ' '.join(command)
             logging.debug(cmd)


### PR DESCRIPTION
should fix https://github.com/WPO-Foundation/webpagetest/issues/913, I didn't see any tests is it mostly a manual setup with a WPT server locally?

blocked on a release with https://github.com/GoogleChrome/lighthouse/pull/3125