### PR TITLE
Use same way to find Python in all scripts

### DIFF
--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Copyright 2016 Google Inc. All Rights Reserved.
 

--- a/internal/support/firefox_log_parser.py
+++ b/internal/support/firefox_log_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Copyright 2016 Google Inc. All Rights Reserved.
 

--- a/internal/support/pcap-parser.py
+++ b/internal/support/pcap-parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Copyright 2016 Google Inc. All Rights Reserved.
 

--- a/internal/support/trace_parser.py
+++ b/internal/support/trace_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Copyright 2016 Google Inc. All Rights Reserved.
 


### PR DESCRIPTION
This makes it easier to debug/run scripts individually on Mac.