### PR TITLE
docker: Less verbose output by default

### DIFF
--- a/docker/linux-headless/entrypoint.sh
+++ b/docker/linux-headless/entrypoint.sh
@@ -29,4 +29,4 @@ fi
 
 # exec replaces the shell process by the python process and is required to
 # propagate signals (i.e. SIGTERM)
-exec python /wptagent/wptagent.py --server "${SERVER_URL}" --location "${LOCATION}" ${EXTRA_ARGS} --xvfb --dockerized -vvvvv
+exec python /wptagent/wptagent.py --server "${SERVER_URL}" --location "${LOCATION}" ${EXTRA_ARGS} --xvfb --dockerized


### PR DESCRIPTION
It's still possible to simply pass `-vvvv` via EXTRA_ARGS, but it shouldn't spam stdout by default.