### PR TITLE
Support full URLs and HTTPS in the wpt_server option

### DIFF
--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -199,7 +199,14 @@ class WebPageTest(object):
                     value = parts[1].strip()
                     logging.debug('Setting config option "%s" to "%s"', key, value)
                     if key == 'wpt_server':
-                        self.url = 'http://{0}/work/'.format(value)
+                        if re.search( r'^https?://', value ):
+                            self.url = value
+                            if value.endswith( '/' ):
+                                self.url += 'work/'
+                            else:
+                                self.url += '/work/'
+                        else:
+                            self.url = 'http://{0}/work/'.format(value)
                     if key == 'wpt_url':
                         self.url = value
                     elif key == 'wpt_loc' or key == 'wpt_location':


### PR DESCRIPTION
The current version of wpt_server only supports bare host names, like `wpt.example.com`.  It also hard codes all wpt_server values to HTTP.  This change allows wpt_server to provide full URLs, with HTTPS, like `https://wpt.example.com/`.

In the case where a bare host name is still provided, the existing code has been preserved.

My Python is still very basic.  If there is a better approach to this I'm happy to have this changed.