### PR TITLE
Cleanup of the Dockerfile to remove layers and large amounts of disk …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,39 +22,39 @@ RUN apt-get update && \
     traceroute \
     bind9utils \
     software-properties-common \
-    python-software-properties
-
-RUN curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash - && \
+    python-software-properties && \
+# Node setup
+  curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash - && \
   wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   wget -qO- https://deb.opera.com/archive.key | apt-key add - && \
-  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
-
-RUN add-apt-repository -y ppa:ubuntu-mozilla-daily/ppa && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
+# Set repos
+  add-apt-repository -y ppa:ubuntu-mozilla-daily/ppa && \
   add-apt-repository -y 'deb https://deb.opera.com/opera-stable/ stable non-free' && \
   add-apt-repository -y 'deb https://deb.opera.com/opera-beta/ stable non-free' && \
-  add-apt-repository -y 'deb https://deb.opera.com/opera-developer/ stable non-free'
-
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -yq \
-    google-chrome-stable \
-    google-chrome-beta \
-    google-chrome-unstable \
-    firefox \
-    firefox-trunk \
-    opera-stable \
-    opera-beta \
-    opera-developer \
-    nodejs
-
-RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections && \
-    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install ttf-mscorefonts-installer fonts-noto* && \
-    sudo fc-cache -f -v
-
-RUN sudo apt-get clean
-
-RUN npm install -g lighthouse
-
-RUN pip install \
+  add-apt-repository -y 'deb https://deb.opera.com/opera-developer/ stable non-free' && \
+# Install browsers
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+  google-chrome-stable \
+  google-chrome-beta \
+  google-chrome-unstable \
+  firefox \
+  firefox-trunk \
+  opera-stable \
+  opera-beta \
+  opera-developer \
+  nodejs && \
+# Get fonts
+  echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections && \
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -y install ttf-mscorefonts-installer fonts-noto* && \
+  sudo fc-cache -f -v && \
+# Cleaup to save space in layer
+  sudo apt-get clean && \
+# Install lighthouse
+  npm install -g lighthouse && \
+# Install other utilities
+  pip install \
     dnspython \
     monotonic \
     pillow \


### PR DESCRIPTION
…consumption

Looks like this Dockerfile was written without too much worrying about number of layers it produced.  This change should reduce the layers (for people that don't flatten after build) and save large amounts of disk space. `apt-get install` and `apt-get cleanup` should also be done in the same command.  Otherwise you end up with intermediate layers that didn't receive the cleanup, needlessly wasting disk space.