### PR TITLE
add teamviewer to keep-lists

### DIFF
--- a/internal/desktop_browser.py
+++ b/internal/desktop_browser.py
@@ -98,7 +98,7 @@ class DesktopBrowser(BaseBrowser):
         """Close all top-level windows"""
         keep_titles = ['Start']
         keep_classes = ['ConsoleWindowClass', 'Windows.UI.Core.CoreWindow']
-        keep_exes = ['explorer.exe', 'cmd.exe']
+        keep_exes = ['explorer.exe', 'cmd.exe', 'teamviewer.exe']
         try:
             import win32api
             import win32con
@@ -145,7 +145,7 @@ class DesktopBrowser(BaseBrowser):
     def close_top_dialog(self, hwnd, _):
         """Close all top-level dialogs"""
         close_classes = ["#32770", "Notepad", "Internet Explorer_Server"]
-        keep_titles = ['Delete Browsing History', 'Shut Down Windows']
+        keep_titles = ['Delete Browsing History', 'Shut Down Windows', 'TeamViewer']
         try:
             import win32gui
             import win32con


### PR DESCRIPTION
Add teamviewer window to the list of application, that not get closed. Otherwise it would be shutdown when used as a remote debugging tool.