### PR TITLE
Fix the blockdomains script command

### DIFF
--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -708,7 +708,7 @@ class WebPageTest(object):
                                 task['block_domains'] = []
                             if 'host_rules' not in task:
                                 task['host_rules'] = []
-                            domains = re.split(', ', target)
+                            domains = re.split('[, ]', target)
                             for domain in domains:
                                 domain = domain.strip()
                                 if len(domain) and domain.find('"') == -1:


### PR DESCRIPTION
The `blockDomains` script command currently does not work as documented because it is only splitting on comma-space (`, `) rather than commas OR spaces. Example scripted test: https://www.webpagetest.org/result/180502_SP_8088c3747356ed604be10ea7f18f598a/

This change makes the `blockDomains` script command consistent with the blockDomains job setting, but inconsistent with the other `block` commands, which only split on a space. @pmeenan is this okay or would you rather just do `target.split()`?