### PR TITLE
Add per-job test_time_limit option

### DIFF
--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -589,7 +589,10 @@ class WebPageTest(object):
                         task['width'] = job['width'] + 20
                         task['height'] = job['height'] + 120
                 task['time_limit'] = job['timeout']
-                task['test_time_limit'] = task['time_limit'] * task['script_step_count']
+                if 'test_time_limit' in job:
+                    task['test_time_limit'] = job['test_time_limit']
+                else:
+                    task['test_time_limit'] = task['time_limit'] * task['script_step_count']
                 task['stop_at_onload'] = bool('web10' in job and job['web10'])
                 task['run_start_time'] = monotonic.monotonic()
                 # Keep the full resolution video frames if the browser window is smaller than 600px


### PR DESCRIPTION
I haven't tested this at all but just wanted to see if it was a potential solution to #120. What do you think @pmeenan? Am I grossly oversimplifying a complex problem?

FWIW, I would pair this with the following patch to webpagetest/runtest.php to allow it to be specified either per-job or in settings.ini.

```php
if( $test['test_time_limit'] )
    AddIniLine($testFile, 'test_time_limit', $test['test_time_limit']);
elseif( $settings['test_time_limit'] )
    AddIniLine($testFile, 'test_time_limit', $settings['test_time_limit']);
```