### PR TITLE
Handle exceeding browser dimensions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -8,6 +8,7 @@ wptagent currently supports Windows, Linux and OSX for desktop browsers as well 
     * pillow
     * psutil
     * pypiwin32 (Windows only)
+    * pyobjc (Mac only)
     * requests
     * ujson
     * tornado

--- a/internal/desktop_browser.py
+++ b/internal/desktop_browser.py
@@ -56,6 +56,8 @@ class DesktopBrowser(BaseBrowser):
         self.task = None
         self.cpu_start = None
         self.throttling_cpu = False
+        self.screen_width = None
+        self.screen_height = None
         self.device_pixel_ratio = None
         self.stopping = False
         self.support_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "support")
@@ -365,6 +367,19 @@ class DesktopBrowser(BaseBrowser):
                     self.execute_js(SET_ORANGE)
                     time.sleep(1)
                 task['video_file'] = os.path.join(task['dir'], task['prefix']) + '_video.mp4'
+                if platform.system() == 'Windows':
+                    from win32api import GetSystemMetrics
+                    self.screen_width = GetSystemMetrics(0)
+                    self.screen_height = GetSystemMetrics(1)
+                elif platform.system() == 'Darwin':
+                    from AppKit import NSScreen
+                    self.screen_width = int(NSScreen.screens()[0].frame().size.width)
+                    self.screen_height = int(NSScreen.screens()[0].frame().size.height)
+                else:
+                    self.screen_width = 1920
+                    self.screen_height = 1200
+                task['width'] = self.screen_width if task['width'] > self.screen_width else task['width']
+                task['height'] = self.screen_height if task['height'] > self.screen_height else task['height']
                 if platform.system() == 'Darwin':
                     width = int(math.ceil(task['width'] * self.device_pixel_ratio))
                     height = int(math.ceil(task['height'] * self.device_pixel_ratio))

--- a/internal/desktop_browser.py
+++ b/internal/desktop_browser.py
@@ -56,8 +56,8 @@ class DesktopBrowser(BaseBrowser):
         self.task = None
         self.cpu_start = None
         self.throttling_cpu = False
-        self.screen_width = None
-        self.screen_height = None
+        self.screen_width = 1920
+        self.screen_height = 1200
         self.device_pixel_ratio = None
         self.stopping = False
         self.support_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "support")
@@ -375,9 +375,6 @@ class DesktopBrowser(BaseBrowser):
                     from AppKit import NSScreen
                     self.screen_width = int(NSScreen.screens()[0].frame().size.width)
                     self.screen_height = int(NSScreen.screens()[0].frame().size.height)
-                else:
-                    self.screen_width = 1920
-                    self.screen_height = 1200
                 task['width'] = self.screen_width if task['width'] > self.screen_width else task['width']
                 task['height'] = self.screen_height if task['height'] > self.screen_height else task['height']
                 if platform.system() == 'Darwin':

--- a/internal/desktop_browser.py
+++ b/internal/desktop_browser.py
@@ -372,11 +372,14 @@ class DesktopBrowser(BaseBrowser):
                     self.screen_width = GetSystemMetrics(0)
                     self.screen_height = GetSystemMetrics(1)
                 elif platform.system() == 'Darwin':
-                    from AppKit import NSScreen
-                    self.screen_width = int(NSScreen.screens()[0].frame().size.width)
-                    self.screen_height = int(NSScreen.screens()[0].frame().size.height)
-                task['width'] = self.screen_width if task['width'] > self.screen_width else task['width']
-                task['height'] = self.screen_height if task['height'] > self.screen_height else task['height']
+                    try:
+                        from AppKit import NSScreen
+                        self.screen_width = int(NSScreen.screens()[0].frame().size.width)
+                        self.screen_height = int(NSScreen.screens()[0].frame().size.height)
+                    except Exception:
+                        pass
+                task['width'] = min(task['width'], self.screen_width)
+                task['height'] = min(task['height'], self.screen_height)
                 if platform.system() == 'Darwin':
                     width = int(math.ceil(task['width'] * self.device_pixel_ratio))
                     height = int(math.ceil(task['height'] * self.device_pixel_ratio))

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -82,9 +82,12 @@ class WebPageTest(object):
                 self.screen_width = GetSystemMetrics(0)
                 self.screen_height = GetSystemMetrics(1)
             elif platform.system() == 'Darwin':
-                from AppKit import NSScreen
-                self.screen_width = int(NSScreen.screens()[0].frame().size.width)
-                self.screen_height = int(NSScreen.screens()[0].frame().size.height)
+                try:
+                    from AppKit import NSScreen
+                    self.screen_width = int(NSScreen.screens()[0].frame().size.width)
+                    self.screen_height = int(NSScreen.screens()[0].frame().size.height)
+                except Exception:
+                    pass
         # See if we have to load dynamic config options
         if self.options.ec2:
             self.load_from_ec2()

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -81,6 +81,10 @@ class WebPageTest(object):
                 from win32api import GetSystemMetrics
                 self.screen_width = GetSystemMetrics(0)
                 self.screen_height = GetSystemMetrics(1)
+            elif platform.system() == 'Darwin':
+                from AppKit import NSScreen
+                self.screen_width = int(NSScreen.screens()[0].frame().size.width)
+                self.screen_height = int(NSScreen.screens()[0].frame().size.height)
         # See if we have to load dynamic config options
         if self.options.ec2:
             self.load_from_ec2()


### PR DESCRIPTION
Based on the issue #123 I added two things:
* the agent also sends the resolution when running on macOS and
* `ffmpeg` gets updated width and height based on the actual dimensions of the host i.e. if the given dimensions exceed the resolution of the system the actual dimensions will be used.