### PR TITLE
Fix detection of hero SVG elements

### DIFF
--- a/internal/js/hero_elements.js
+++ b/internal/js/hero_elements.js
@@ -19,7 +19,7 @@ docElements.forEach(function(element) {
   var elementRect = element.getBoundingClientRect();
   var elementArea = visibleElementArea(elementRect);
 
-  if (isVisibleElement(element) && isInViewport(elementRect)) {
+  if (isVisibleElement(elementRect) && isInViewport(elementRect)) {
     // Specific elements we look for - headings and images
     if (element.tagName === 'H1' && isLargestHero('h1', elementArea)) {
       setHeroElement('h1', elementRect, elementArea);
@@ -63,7 +63,7 @@ if (typeof customHeroSelectors === 'object') {
       var elementRect = element.getBoundingClientRect();
       var elementArea = visibleElementArea(elementRect);
 
-      if (isVisibleElement(element) && isInViewport(elementRect)) {
+      if (isVisibleElement(elementRect) && isInViewport(elementRect)) {
         setHeroElement(heroName, elementRect, elementArea);
       }
     }
@@ -102,8 +102,8 @@ function isLargestHero(name, area) {
   );
 }
 
-function isVisibleElement(el) {
-  return el.offsetHeight > 0;
+function isVisibleElement(rect) {
+  return rect.height > 0;
 }
 
 function isInViewport(rect) {


### PR DESCRIPTION
Found this bug while I was doing some testing on public. `SVGElement.offsetHeight` was deprecated some years ago and has since been removed from most browsers. Using on `DOMRect.height` instead so that SVG heroes are detected correctly.