### PR TITLE
Run visualmetrics.py with verbose logging (-vvvv) when debug=1

### DIFF
--- a/internal/android_browser.py
+++ b/internal/android_browser.py
@@ -184,6 +184,8 @@ class AndroidBrowser(BaseBrowser):
                         '{0:d}'.format(self.job['imageQuality']),
                         '--viewport', '--maxframes', '50', '--histogram', histograms,
                         '--progress', progress_file]
+                if 'debug' in self.job and self.job['debug']:
+                    args.append('-vvvv')
                 if 'heroElementTimes' in self.job and self.job['heroElementTimes']:
                     hero_elements_file = os.path.join(task['dir'], task['prefix']) + '_hero_elements.json.gz'
                     args.extend(['--herodata', hero_elements_file])

--- a/internal/desktop_browser.py
+++ b/internal/desktop_browser.py
@@ -511,6 +511,8 @@ class DesktopBrowser(BaseBrowser):
                     '{0:d}'.format(self.job['imageQuality']),
                     '--viewport', '--orange', '--maxframes', '50', '--histogram', histograms,
                     '--progress', progress_file]
+            if 'debug' in self.job and self.job['debug']:
+                args.append('-vvvv')
             if not task['navigated']:
                 args.append('--forceblank')
             if 'heroElementTimes' in self.job and self.job['heroElementTimes']:

--- a/internal/safari_ios.py
+++ b/internal/safari_ios.py
@@ -846,6 +846,8 @@ class iWptBrowser(BaseBrowser):
                         '{0:d}'.format(self.job['imageQuality']),
                         '--viewport', '--orange', '--maxframes', '50', '--histogram', histograms,
                         '--progress', progress_file]
+                if 'debug' in self.job and self.job['debug']:
+                    args.append('-vvvv')
                 if 'heroElementTimes' in self.job and self.job['heroElementTimes']:
                     hero_elements_file = os.path.join(task['dir'], task['prefix']) + '_hero_elements.json.gz'
                     args.extend(['--herodata', hero_elements_file])


### PR DESCRIPTION
I find it useful to run visualmetrics.py with -vvvv when I'm debugging. It would be nice if this was done automatically based on the debug option.

The one thing I'm not sure of is whether it's possible to get this output from the WPT UI? I primarily test in a Docker container, so I see all the console output. It would be nice to be able to see the output somehow when running tests on webpagetest.org.