### PR TITLE
Fix hero element race condition

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -166,6 +166,20 @@ class DevtoolsBrowser(object):
         if self.devtools is not None:
             self.devtools.stop_capture()
 
+            if 'heroElementTimes' in self.job and self.job['heroElementTimes']:
+                hero_elements = None
+                custom_hero_selectors = {}
+                if 'heroElements' in self.job:
+                    custom_hero_selectors = self.job['heroElements']
+                with open(os.path.join(self.script_dir, 'hero_elements.js'), 'rb') as script_file:
+                    hero_elements_script = script_file.read()
+                script = hero_elements_script + '(' + json.dumps(custom_hero_selectors) + ')'
+                hero_elements = self.devtools.execute_js(script)
+                if hero_elements is not None:
+                    path = os.path.join(task['dir'], task['prefix'] + '_hero_elements.json.gz')
+                    with gzip.open(path, 'wb', 7) as outfile:
+                        outfile.write(json.dumps(hero_elements))
+
     def on_stop_recording(self, task):
         """Stop recording"""
         if self.devtools is not None:
@@ -318,19 +332,6 @@ class DevtoolsBrowser(object):
         page_data = self.run_js_file('page_data.js')
         if page_data is not None:
             task['page_data'].update(page_data)
-        if 'heroElementTimes' in self.job and self.job['heroElementTimes']:
-            hero_elements = None
-            custom_hero_selectors = {}
-            if 'heroElements' in self.job:
-                custom_hero_selectors = self.job['heroElements']
-            with open(os.path.join(self.script_dir, 'hero_elements.js'), 'rb') as script_file:
-                hero_elements_script = script_file.read()
-            script = hero_elements_script + '(' + json.dumps(custom_hero_selectors) + ')'
-            hero_elements = self.devtools.execute_js(script)
-            if hero_elements is not None:
-                path = os.path.join(task['dir'], task['prefix'] + '_hero_elements.json.gz')
-                with gzip.open(path, 'wb', 7) as outfile:
-                    outfile.write(json.dumps(hero_elements))
         if 'customMetrics' in self.job:
             custom_metrics = {}
             for name in self.job['customMetrics']:

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -381,20 +381,6 @@ class Firefox(DesktopBrowser):
         page_data = self.run_js_file('page_data.js')
         if page_data is not None:
             task['page_data'].update(page_data)
-        if 'heroElementTimes' in self.job and self.job['heroElementTimes']:
-            hero_elements = None
-            custom_hero_selectors = {}
-            if 'heroElements' in self.job:
-                custom_hero_selectors = self.job['heroElements']
-            logging.debug('Collecting hero element positions')
-            with open(os.path.join(self.script_dir, 'hero_elements.js'), 'rb') as script_file:
-                hero_elements_script = script_file.read()
-            script = hero_elements_script + '(' + json.dumps(custom_hero_selectors) + ')'
-            hero_elements = self.execute_js(script)
-            if hero_elements is not None:
-                path = os.path.join(task['dir'], task['prefix'] + '_hero_elements.json.gz')
-                with gzip.open(path, 'wb', 7) as outfile:
-                    outfile.write(json.dumps(hero_elements))
         if 'customMetrics' in self.job:
             custom_metrics = {}
             for name in self.job['customMetrics']:
@@ -582,6 +568,20 @@ class Firefox(DesktopBrowser):
     def on_stop_capture(self, task):
         """Do any quick work to stop things that are capturing data"""
         DesktopBrowser.on_stop_capture(self, task)
+        if 'heroElementTimes' in self.job and self.job['heroElementTimes']:
+            hero_elements = None
+            custom_hero_selectors = {}
+            if 'heroElements' in self.job:
+                custom_hero_selectors = self.job['heroElements']
+            logging.debug('Collecting hero element positions')
+            with open(os.path.join(self.script_dir, 'hero_elements.js'), 'rb') as script_file:
+                hero_elements_script = script_file.read()
+            script = hero_elements_script + '(' + json.dumps(custom_hero_selectors) + ')'
+            hero_elements = self.execute_js(script)
+            if hero_elements is not None:
+                path = os.path.join(task['dir'], task['prefix'] + '_hero_elements.json.gz')
+                with gzip.open(path, 'wb', 7) as outfile:
+                    outfile.write(json.dumps(hero_elements))
 
     def on_stop_recording(self, task):
         """Notification that we are done with recording"""

--- a/internal/microsoft_edge.py
+++ b/internal/microsoft_edge.py
@@ -652,20 +652,6 @@ class Edge(DesktopBrowser):
         page_data = self.run_js_file('page_data.js')
         if page_data is not None:
             task['page_data'].update(page_data)
-        if 'heroElementTimes' in self.job and self.job['heroElementTimes']:
-            hero_elements = None
-            custom_hero_selectors = {}
-            if 'heroElements' in self.job:
-                custom_hero_selectors = self.job['heroElements']
-            logging.debug('Collecting hero element positions')
-            with open(os.path.join(self.script_dir, 'hero_elements.js'), 'rb') as script_file:
-                hero_elements_script = script_file.read()
-            script = hero_elements_script + '(' + json.dumps(custom_hero_selectors) + ')'
-            hero_elements = self.execute_js(script)
-            if hero_elements is not None:
-                path = os.path.join(task['dir'], task['prefix'] + '_hero_elements.json.gz')
-                with gzip.open(path, 'wb', 7) as outfile:
-                    outfile.write(json.dumps(hero_elements))
         if 'customMetrics' in self.job:
             self.driver.set_script_timeout(30)
             custom_metrics = {}
@@ -740,6 +726,20 @@ class Edge(DesktopBrowser):
     def on_stop_capture(self, task):
         """Do any quick work to stop things that are capturing data"""
         DesktopBrowser.on_stop_capture(self, task)
+        if 'heroElementTimes' in self.job and self.job['heroElementTimes']:
+            hero_elements = None
+            custom_hero_selectors = {}
+            if 'heroElements' in self.job:
+                custom_hero_selectors = self.job['heroElements']
+            logging.debug('Collecting hero element positions')
+            with open(os.path.join(self.script_dir, 'hero_elements.js'), 'rb') as script_file:
+                hero_elements_script = script_file.read()
+            script = hero_elements_script + '(' + json.dumps(custom_hero_selectors) + ')'
+            hero_elements = self.execute_js(script)
+            if hero_elements is not None:
+                path = os.path.join(task['dir'], task['prefix'] + '_hero_elements.json.gz')
+                with gzip.open(path, 'wb', 7) as outfile:
+                    outfile.write(json.dumps(hero_elements))
 
     def on_stop_recording(self, task):
         """Notification that we are done with recording"""

--- a/internal/safari_ios.py
+++ b/internal/safari_ios.py
@@ -315,20 +315,6 @@ class iWptBrowser(BaseBrowser):
         logging.debug(page_data)
         if page_data is not None:
             task['page_data'].update(page_data)
-        if 'heroElementTimes' in self.job and self.job['heroElementTimes']:
-            hero_elements = None
-            custom_hero_selectors = {}
-            if 'heroElements' in self.job:
-                custom_hero_selectors = self.job['heroElements']
-            logging.debug('Collecting hero element positions')
-            with open(os.path.join(self.script_dir, 'hero_elements.js'), 'rb') as script_file:
-                hero_elements_script = script_file.read()
-            script = hero_elements_script + '(' + json.dumps(custom_hero_selectors) + ')'
-            hero_elements = self.ios.execute_js(script)
-            if hero_elements is not None:
-                path = os.path.join(task['dir'], task['prefix'] + '_hero_elements.json.gz')
-                with gzip.open(path, 'wb', 7) as outfile:
-                    outfile.write(json.dumps(hero_elements))
         if 'customMetrics' in self.job:
             custom_metrics = {}
             for name in self.job['customMetrics']:
@@ -778,7 +764,20 @@ class iWptBrowser(BaseBrowser):
 
     def on_stop_capture(self, task):
         """Do any quick work to stop things that are capturing data"""
-        pass
+        if 'heroElementTimes' in self.job and self.job['heroElementTimes']:
+            hero_elements = None
+            custom_hero_selectors = {}
+            if 'heroElements' in self.job:
+                custom_hero_selectors = self.job['heroElements']
+            logging.debug('Collecting hero element positions')
+            with open(os.path.join(self.script_dir, 'hero_elements.js'), 'rb') as script_file:
+                hero_elements_script = script_file.read()
+            script = hero_elements_script + '(' + json.dumps(custom_hero_selectors) + ')'
+            hero_elements = self.ios.execute_js(script)
+            if hero_elements is not None:
+                path = os.path.join(task['dir'], task['prefix'] + '_hero_elements.json.gz')
+                with gzip.open(path, 'wb', 7) as outfile:
+                    outfile.write(json.dumps(hero_elements))
 
     def on_stop_recording(self, task):
         """Notification that we are done with recording"""

--- a/internal/support/visualmetrics.py
+++ b/internal/support/visualmetrics.py
@@ -1314,11 +1314,13 @@ def calculate_visual_metrics(histograms_file, start, end, perceptual, dirs, prog
                 metrics.append({'name': 'Perceptual Speed Index',
                                 'value': calculate_perceptual_speed_index(progress, dirs)})
             if hero_elements_file is not None and os.path.isfile(hero_elements_file):
+                logging.debug('Calculating hero element times')
                 hero_data = None
                 hero_f_in = gzip.open(hero_elements_file, 'rb')
                 try:
                     hero_data = json.load(hero_f_in)
                 except Exception as e:
+                    logging.exception('Could not load hero elements data')
                     logging.exception(e)
                 hero_f_in.close()
 
@@ -1340,6 +1342,8 @@ def calculate_visual_metrics(histograms_file, start, end, perceptual, dirs, prog
                     hero_f_out = gzip.open(hero_elements_file, 'wb', 7)
                     json.dump(hero_data, hero_f_out)
                     hero_f_out.close()
+            else:
+                logging.warn('Hero elements file is not valid: ' + str(hero_elements_file))
         else:
             metrics = [
                 {'name': 'First Visual Change',


### PR DESCRIPTION
Hey @pmeenan, hoping to get your advice on this. I've been monitoring the hero elements code very closely for the last week or so, and I've identified a race condition on some tests where visualmetrics.py is run before the hero element positions are extracted.

The issue is basically that I put the hero element code in a silly place - after you'd expect visualmetrics.py to run. The order of execution sort of looks like this:

```
WPTAgent.run_testing()
	ChromeDesktop.on_stop_capture()
		DesktopBrowser.on_stop_capture()
		DevtoolsBrowser.on_stop_capture()

	ChromeDesktop.on_stop_recording()
		DesktopBrowser.on_stop_recording()
			<wait for tcpdump and ffmpeg to stop>
			<call visualmetrics.py>**

		DevtoolsBrowser.on_stop_recording()
			DevtoolsBrowser.collect_browser_metrics()
				<hero elements positions extracted here>**
```

For whatever reason, most pages seem to identify the hero elements before visualmetrics.py is run. I guess there's some async stuff going on in there? But on pages with many many requests, it must take longer for the devtools stuff to finish up, and the hero elements are not identified until too late.

To solve this problem, I've moved the hero element identification from `on_stop_recording()` to `on_stop_capture()`. But is this the right place? I feel like I can't really justify why it belongs there except for "so that it runs before visualmetrics.py"... LMK what you think.