### PR TITLE
Fix #164: correct handling of multiple block_domains_except in Firefox

### DIFF
--- a/internal/support/Firefox/extension/background.js
+++ b/internal/support/Firefox/extension/background.js
@@ -79,11 +79,8 @@ function blockRequest(details) {
       }
     }
     if (!ret.cancel && block_domains_except.length > 0) {
-      for (var i = 0; i < block_domains_except.length; i++) {
-        if (domain != block_domains_except[i]) {
-          ret.cancel = true;
-          break;
-        }
+      if (!block_domains_except.includes(domain)) {
+        ret.cancel = true;
       }
     }
   }


### PR DESCRIPTION
The current logic doesn't correctly handle multiple arguments to blockDomainsExcept.