### PR TITLE
Fix detection of hero BG images and elements with `elementtiming` attribute

### DIFF
--- a/internal/js/hero_elements.js
+++ b/internal/js/hero_elements.js
@@ -30,13 +30,13 @@ docElements.forEach(function(element) {
     }
 
     // Always check if an element has a background image
-    if (hasValidBackgroundImage(element) && elementArea > elementAreas['BackgroundImage']) {
-      setHeroElement('BackgroundImage', rect, elementArea);
+    if (hasValidBackgroundImage(element) && isLargestHero('BackgroundImage', elementArea)) {
+      setHeroElement('BackgroundImage', elementRect, elementArea);
     }
 
     // Always record elements with the 'elementtiming' attribute
     if (element.getAttribute('elementtiming')) {
-      setHeroElement(element.getAttribute('elementtiming'), rect, elementArea);
+      setHeroElement(element.getAttribute('elementtiming'), elementRect, elementArea);
     }
   }
 });


### PR DESCRIPTION
Had this hero elements stuff on the back burner for a couple of weeks but I'm back at it! We're now running with this enabled for all SpeedCurve tests, and I'm tracking differences between our implementation and the wptagent implementation.