### PR TITLE
Increase hero frame match fuzz to 5%

### DIFF
--- a/internal/support/visualmetrics.py
+++ b/internal/support/visualmetrics.py
@@ -1543,7 +1543,7 @@ def calculate_hero_time(progress, directory, hero, viewport):
                     image_magick['convert'], current_frame + extension, hero_mask, current_mask)
                 logging.debug(command)
                 subprocess.call(command, shell=True)
-                match = frames_match(target_mask, current_mask, 2, 0, None, None)
+                match = frames_match(target_mask, current_mask, 5, 0, None, None)
                 # Remove each mask after using it
                 os.remove(current_mask)
 


### PR DESCRIPTION
I've been slowly working through some anomalous hero element times and most of them appear to be "fuzziness" issues. For example, the background image behind the H1 on this page is _nearly_ the same colour as the body background colour.
 
![hero-fuzz](https://user-images.githubusercontent.com/794263/44692472-2b7ab800-aab7-11e8-97a8-e3c3e12ee506.png)

There's nothing scientific about the way I picked the fuzz factor. For the frames above, 3% fuzz factor is enough to match the frames. @pmeenan I'm curious whether you have any opinions on what a good fuzz factor is? I'm being pretty conservative since `frames_match` will be working with PNGs so there should be no compression artefacts to "fuzz out".