### PR TITLE
Pass custom user agent through to Lighthouse via --chrome-flags

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -477,6 +477,8 @@ class DevtoolsBrowser(object):
                 command.append('--save-assets')
             if self.options.android or 'mobile' not in self.job or not self.job['mobile']:
                 command.append('--disable-device-emulation')
+                if 'user_agent_string' in self.job:
+                    command.append('--chrome-flags="--user-agent=\'{0}\'"'.format(self.job['user_agent_string']))
             if len(task['block']):
                 for pattern in task['block']:
                     pattern = "'" + pattern.replace("'", "'\\''") + "'"

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -478,7 +478,8 @@ class DevtoolsBrowser(object):
             if self.options.android or 'mobile' not in self.job or not self.job['mobile']:
                 command.append('--disable-device-emulation')
                 if 'user_agent_string' in self.job:
-                    command.append('--chrome-flags="--user-agent=\'{0}\'"'.format(self.job['user_agent_string']))
+                    sanitized_user_agent = re.sub(r'[^a-zA-Z0-9_\-.;:/()\[\] ]+', '', self.job['user_agent_string'])
+                    command.append('--chrome-flags="--user-agent=\'{0}\'"'.format(sanitized_user_agent))
             if len(task['block']):
                 for pattern in task['block']:
                     pattern = "'" + pattern.replace("'", "'\\''") + "'"


### PR DESCRIPTION
This solves the (somewhat esoteric) problem of wanting Lighthouse to use custom UA strings rather than the default Chrome string.

Kind of a pain that this is only possible when device emulation is disabled, though. Maybe I'm better off seeing if the Lighthouse team would be open to a `--user-agent` or similar flag that could set the UA via puppeteer?
