### PR TITLE
Add beta Firefox metric timeToInteractive (TTI) to prefs.js + page data

### DIFF
--- a/internal/js/page_data.js
+++ b/internal/js/page_data.js
@@ -17,12 +17,13 @@ function addTime(name) {
   } catch(e) {}
 };
 addTime("domInteractive");
-addTime("domContentFlushed");
 addTime("domContentLoadedEventStart");
 addTime("domContentLoadedEventEnd");
-addTime("domComplete");
+addTime("domContentFlushed");
+addtime("domComplete");
 addTime("loadEventStart");
 addTime("loadEventEnd");
+addtime("timeToInteractive");
 pageData["firstPaint"] = 0;
 // Try the standardized paint timing api
 try {

--- a/internal/support/Firefox/profile/prefs.js
+++ b/internal/support/Firefox/profile/prefs.js
@@ -55,6 +55,7 @@ user_pref("dom.max_chrome_script_run_time", 0);
 user_pref("dom.max_script_run_time", 0);
 user_pref("dom.webnotifications.enabled", false);
 user_pref("dom.performance.time_to_dom_content_flushed.enabled", true);
+user_pref("dom.performance.time_to_interactive.enabled", true);
 user_pref("dom.performance.time_to_non_blank_paint.enabled", true);
 user_pref("extensions.checkCompatibility", false);
 user_pref("extensions.pocket.enabled", false);


### PR DESCRIPTION
This patch (hopefully) adds in support for Firefox's brand-new ```timeToInteractive``` (```TTI```) metric, which is implemented in https://bugzilla.mozilla.org/show_bug.cgi?id=1299118

The metric itself will be refined + evolved (hence the beta moniker for now); right now, it's missing network events[0], and uses ```timeToFirstNonBlankPaint``` (```TTFNBP```), rather than ```firstContentfulPaint``` (```FCP```).

[0] (a familiar theme, eh, @pmeenan?  - I'm working internally on getting Firefox, Dev Tools, networking, and logging all happily together, just FYI)

/cc @soulgalore @jmaher @rwood-moz @stuartphilp @karlht @digitarald

