### PR TITLE
Use correct timeToFirstInteractive DOM-metric name

### DIFF
--- a/internal/js/page_data.js
+++ b/internal/js/page_data.js
@@ -23,7 +23,7 @@ addTime("domContentFlushed");
 addtime("domComplete");
 addTime("loadEventStart");
 addTime("loadEventEnd");
-addtime("timeToInteractive");
+addtime("timeToFirstInteractive");
 pageData["firstPaint"] = 0;
 // Try the standardized paint timing api
 try {


### PR DESCRIPTION
@pmeenan apologies, again - was too early with (by a couple days) and misunderstood *which* metric we were supporting (x-ref https://github.com/WPO-Foundation/wptagent/pull/190).

This should be the correct, longer-term one, sorry!

/cc @jesup 