### PR TITLE
Allow isMainFrame to override any previously-set main thread value

### DIFF
--- a/internal/support/trace_parser.py
+++ b/internal/support/trace_parser.py
@@ -239,7 +239,7 @@ class Trace():
             if 'url' in trace_event['args']['data'] and \
                     trace_event['args']['data']['url'].startswith('http://127.0.0.1:8888'):
                 self.ignore_threads[thread] = True
-            if self.cpu['main_thread'] is None:
+            if self.cpu['main_thread'] is None or 'isMainFrame' in trace_event['args']['data']:
                 if ('isMainFrame' in trace_event['args']['data'] and \
                      trace_event['args']['data']['isMainFrame']) or \
                    (trace_event['name'] == 'ResourceSendRequest' and \


### PR DESCRIPTION
So this is obviously a really naïve solution, but it seems like the problem with #197 is that some subframe processes are able to meet the `trace_event['name'] == 'ResourceSendRequest' and 'url' in trace_event['args']['data']` criteria.

I figure if `isMainFrame` is available, we should let that take priority instead.