### PR TITLE
Hero time adjustments

### DIFF
--- a/internal/js/hero_elements.js
+++ b/internal/js/hero_elements.js
@@ -125,16 +125,17 @@ function isInViewport(rect) {
   );
 }
 
-// Check if an element has a non-repeating background loaded from a URL
+// Check if an element has a background loaded from a URL
 function hasValidBackgroundImage(el) {
   var computedStyle = window.getComputedStyle(el);
   var elementBgImg = computedStyle.backgroundImage.toLowerCase();
+  var isRepeating = ['repeat', 'repeat-x', 'repeat-y'].indexOf(computedStyle.backgroundRepeat) !== -1;
+  var isCovering = computedStyle.backgroundSize.toLowerCase() === 'cover';
 
   return (
     elementBgImg.indexOf('url(') === 0 &&
-    computedStyle.backgroundRepeat !== 'repeat' &&
-    computedStyle.backgroundRepeat !== 'repeat-x' &&
-    computedStyle.backgroundRepeat !== 'repeat-y'
+    // We want to ignore repeating patterns, but background-size: cover supersedes this
+    (!isRepeating || isCovering)
   );
 }
 

--- a/internal/support/visualmetrics.py
+++ b/internal/support/visualmetrics.py
@@ -1529,6 +1529,12 @@ def calculate_hero_time(progress, directory, hero, viewport):
             if os.path.isfile(target_mask):
                 os.remove(target_mask)
 
+        # Allow for small differences like scrollbars and overlaid UI elements
+        # by applying a 10% fuzz and allowing for up to 2% of the pixels to be
+        # different.
+        fuzz = 10
+        max_pixel_diff = math.ceil(hero_width * hero_height * 0.02)
+
         for p in progress:
             current_frame = os.path.join(dir, 'ms_{0:06d}'.format(p['time']))
             extension = None
@@ -1543,7 +1549,7 @@ def calculate_hero_time(progress, directory, hero, viewport):
                     image_magick['convert'], current_frame + extension, hero_mask, current_mask)
                 logging.debug(command)
                 subprocess.call(command, shell=True)
-                match = frames_match(target_mask, current_mask, 5, 0, None, None)
+                match = frames_match(target_mask, current_mask, fuzz, max_pixel_diff, None, None)
                 # Remove each mask after using it
                 os.remove(current_mask)
 


### PR DESCRIPTION
I've had time to analyse more results for the hero element timings. This patch does a couple of things:

1. Improves detection of background images. Previously we were ignoring all repeating backgrounds in an attempt to focus on larger images rather than small repeating patterns. Now we let `background-size: cover` supersede this.
2. Increases the fuzz factor to 10% and allows for some different pixels. I kind of figured this was inevitable but wanted to see what sort of results we got from doing a more "strict" comparison. This basically accounts for things like overflow scrollbars or those little navigation dots in image carousels. These UI overlays don't contribute to the feeling of the hero element being ready, so I think that adding some leeway for them makes sense.