### PR TITLE
Firefox Multistep: Wrong timings and request order

### DIFF
--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -414,10 +414,11 @@ class Firefox(DesktopBrowser):
                     elapsed = event_time - self.task['start_time']
                     message['body']['timeStamp'] = elapsed.total_seconds()
                 cat, msg = message['path'].split('.', 1)
-                if cat == 'webNavigation':
-                    self.process_web_navigation(msg, message['body'])
-                elif cat == 'webRequest':
-                    self.process_web_request(msg, message['body'])
+                if 'timeStamp' not in message['body'] or message['body']['timeStamp'] > 0:
+                    if cat == 'webNavigation':
+                        self.process_web_navigation(msg, message['body'])
+                    elif cat == 'webRequest':
+                        self.process_web_request(msg, message['body'])
             except Exception:
                 pass
 

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -648,7 +648,7 @@ class Firefox(DesktopBrowser):
                 except Exception:
                     pass
         # Build the request and page data
-        if len(request_timings) and task['current_step'] == 1:
+        if len(request_timings) and task['current_step'] >= 1:
             self.adjust_timings(request_timings)
         self.process_requests(request_timings, task)
 


### PR DESCRIPTION
This should fix https://github.com/WPO-Foundation/wptagent/issues/189

The firefox code will now only accept extension messages, which where send after the step was started. This should prevent requests, which were started while calculating the current step to appear in the following step.

Additionally all steps after the first one would't start at 0 (see screeshot below), this was fixed by calling adjust_timings for every step, instead of just the first one. This also fixed the wrong order of requests, mentioned in the issue above.

These three bugs where kind of related(see https://github.com/WPO-Foundation/wptagent/issues/189).
![ff_offset](https://user-images.githubusercontent.com/12231522/47343577-b1c20d80-d6a6-11e8-90ee-92fb50a58240.png)
