### PR TITLE
Rename Firefox-internal domContentFlushed back to its raw timeToDOMCo…

### DIFF
--- a/internal/js/page_data.js
+++ b/internal/js/page_data.js
@@ -19,7 +19,7 @@ function addTime(name) {
 addTime("domInteractive");
 addTime("domContentLoadedEventStart");
 addTime("domContentLoadedEventEnd");
-addTime("domContentFlushed");
+addTime("timeToDOMContentFlushed");
 addTime("domComplete");
 addTime("loadEventStart");
 addTime("loadEventEnd");


### PR DESCRIPTION
…ntentFlushed metric

Since we need to calculate ```domContentFlushed``` [sic] by (for now, on our side) by subtracting ```timeToDOMContentFlushed``` from ```fetchStart```, we need to rename it back to its raw metric, ```timeToDOMContentFlushed```.

Sorry for the back and forth on these Firefox-internal metrics (not to mention breaking things!) - I was flying solo for a bit, and expect help soon for things WPT + Firefox.

I've made a similar change in our private instance: https://github.com/mozilla-services/webpagetest-settings/blob/dd9c5ff83235c49312f360eac1db1f4a6e90d8bc/custom_metrics/timeToDOMContentFlushed.js