### PR TITLE
Check all CDN headers for layered CDNs

### DIFF
--- a/internal/optimization_checks.py
+++ b/internal/optimization_checks.py
@@ -636,6 +636,7 @@ class OptimizationChecks(object):
 
     def check_cdn_headers(self, headers):
         """Check the given headers against our header list"""
+        matched_cdns = []
         for cdn in self.cdn_headers:
             for header_group in self.cdn_headers[cdn]:
                 all_match = True
@@ -651,8 +652,13 @@ class OptimizationChecks(object):
                             all_match = False
                             break
                 if all_match:
-                    return cdn
-        return None
+                    matched_cdns.append(cdn)
+                    break;
+
+        if not len(matched_cdns):
+            return None
+
+        return ', '.join(matched_cdns)
 
     def check_gzip(self):
         """Check each request to see if it can be compressed"""


### PR DESCRIPTION
Resolves https://github.com/WPO-Foundation/wptagent/issues/203

Since headers are the only thing that could match against 2 CDNs I just added this logic here and not to the cname checking. 

Before:
![screen shot 2018-10-29 at 2 38 40 pm](https://user-images.githubusercontent.com/4588318/47673680-b8132680-db8b-11e8-95af-2fec107cccad.png)

After:
![screen shot 2018-10-29 at 2 38 47 pm](https://user-images.githubusercontent.com/4588318/47673681-b8132680-db8b-11e8-98b1-c8cbb34a9d64.png)
