### PR TITLE
Fix pref-name for time_to_first_interactive in Firefox

### DIFF
--- a/internal/support/Firefox/profile/prefs.js
+++ b/internal/support/Firefox/profile/prefs.js
@@ -55,7 +55,7 @@ user_pref("dom.max_chrome_script_run_time", 0);
 user_pref("dom.max_script_run_time", 0);
 user_pref("dom.webnotifications.enabled", false);
 user_pref("dom.performance.time_to_dom_content_flushed.enabled", true);
-user_pref("dom.performance.time_to_interactive.enabled", true);
+user_pref("dom.performance.time_to_first_interactive.enabled", true);
 user_pref("dom.performance.time_to_non_blank_paint.enabled", true);
 user_pref("extensions.checkCompatibility", false);
 user_pref("extensions.pocket.enabled", false);


### PR DESCRIPTION
@pmeenan when I get a chance later tonight, I'll double-check whether/when the pref name changed, but I do know that **this** one is the correct one, based on https://searchfox.org/mozilla-central/rev/fc3d974254660b34638b2af9d5431618b191b233/modules/libpref/init/all.js#186 and our other project, Raptor: https://wiki.mozilla.org/Performance_sheriffing/Raptor

r?  if you would please be so kind?  And sorry!

/cc @davehunt @soulgalore @philbooth @stuartphilp @karlht @rwood-moz @jmaher