### PR TITLE
Firefox: set media.gmp-provider.enabled to false in prefs.js

### DIFF
--- a/internal/support/Firefox/profile/prefs.js
+++ b/internal/support/Firefox/profile/prefs.js
@@ -68,6 +68,7 @@ user_pref("geo.prompt.testing", true);
 user_pref("geo.prompt.testing.allow", true);
 user_pref("intl.charsetmenu.browser.cache", "UTF-8");
 user_pref("media.gmp-gmpopenh264.autoupdate", false);
+user_pref("media.gmp-provider.enabled", false);
 user_pref("network.captive-portal-service.enabled", false);
 user_pref("network.cookie.prefsMigrated", true);
 user_pref("network.proxy.type", 0);


### PR DESCRIPTION
This is my attempt to try to fix/mitigate https://bugzilla.mozilla.org/show_bug.cgi?id=1456705.

@pmeenan @davehunt @soulgalore thoughts/r?