### PR TITLE
[WIP] Firefox prefs: Add and enable a beta+ (ready to vet) timeToContentful…

### DIFF
--- a/internal/js/page_data.js
+++ b/internal/js/page_data.js
@@ -19,6 +19,7 @@ function addTime(name) {
 addTime("domInteractive");
 addTime("domContentLoadedEventStart");
 addTime("domContentLoadedEventEnd");
+addTime("timeToContentfulPaint");
 addTime("timeToDOMContentFlushed");
 addTime("domComplete");
 addTime("loadEventStart");

--- a/internal/support/Firefox/profile/prefs.js
+++ b/internal/support/Firefox/profile/prefs.js
@@ -55,6 +55,7 @@ user_pref("dom.max_chrome_script_run_time", 0);
 user_pref("dom.max_script_run_time", 0);
 user_pref("dom.webnotifications.enabled", false);
 user_pref("dom.performance.time_to_dom_content_flushed.enabled", true);
+user_pref("dom.performance.time_to_contentful_paint.enabled", true);
 user_pref("dom.performance.time_to_first_interactive.enabled", true);
 user_pref("dom.performance.time_to_non_blank_paint.enabled", true);
 user_pref("extensions.checkCompatibility", false);


### PR DESCRIPTION
…Paint metric.

Landed in Mozilla Central (and subsequently backed out, hence this as [WIP] for now): https://hg.mozilla.org/integration/mozilla-inbound/rev/91659baa6ddb.

Note that we're
1) still missing the network-requests portion of ```(time to) First Contentful Paint```  (and see #3, below)
2) IIRC, temporarily using ```(time to) First Non-Blank Paint``` in lieu of ```First Meaningful Paint```
3) calling it ```timeToContentfulPaint``` in the interim, until we implement the network-requests detection logic in #1, above

See also: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/name

I've confirmed with our Firefox Performance team that it's the right metric to return (for us, at least as we're tracking and refining it), in the interim:

https://hg.mozilla.org/integration/mozilla-inbound/file/91659baa6ddb/dom/webidl/PerformanceTiming.webidl#l44

/cc @davehunt @soulgalore @onkeltom @godelstheory @robwood-moz 
