### PR TITLE
Firefox - sets most log levels to 1, from 5; x-ref Bugzilla bug # 1452535

### DIFF
--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -54,8 +54,8 @@ class Firefox(DesktopBrowser):
         self.requests = {}
         self.main_request_headers = None
         os.environ["MOZ_LOG_FILE"] = self.moz_log
-        os.environ["MOZ_LOG"] = 'timestamp,sync,nsHttp:5,nsSocketTransport:5'\
-                                'nsHostResolver:5,pipnss:5'
+        os.environ["MOZ_LOG"] = 'timestamp,sync,nsHttp:1,nsSocketTransport:1'\
+                                'nsHostResolver:1,pipnss:5'
         DesktopBrowser.prepare(self, job, task)
         profile_template = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                                         'support', 'Firefox', 'profile')


### PR DESCRIPTION
@davehunt @pmeenan @soulgalore this is, as the title notes, the corresponding WebPageTest-side changes to some Firefox log levels in the client (https://bugzilla.mozilla.org/show_bug.cgi?id=1452535), to address runtime/startup overhead.

r?