### PR TITLE
[WIP] Add new, correct domContentFlushed (Fx-only) metric; remove raw timeT…

### DIFF
--- a/internal/js/page_data.js
+++ b/internal/js/page_data.js
@@ -24,11 +24,12 @@ addTime("domComplete");
 addTime("loadEventStart");
 addTime("loadEventEnd");
 addTime("timeToFirstInteractive");
-pageData["domContentFlushed"];
-var perfData = window.performance;
-var domContentFlushed = perfData.timing.timeToDOMContentFlushed - perfData.timing.fetchStart;
-return domContentFlushed;
-
+try {
+    if (window.performance.timing['timeToDOMContentFlushed']) {
+        pageData["domContentFlushed"] = window.performance.timing.timeToDOMContentFlushed - window.performance.timing.fetchStart;
+    }
+} catch(e) {
+}
 pageData["firstPaint"] = 0;
 // Try the standardized paint timing api
 try {

--- a/internal/js/page_data.js
+++ b/internal/js/page_data.js
@@ -20,11 +20,15 @@ addTime("domInteractive");
 addTime("domContentLoadedEventStart");
 addTime("domContentLoadedEventEnd");
 addTime("timeToContentfulPaint");
-addTime("timeToDOMContentFlushed");
 addTime("domComplete");
 addTime("loadEventStart");
 addTime("loadEventEnd");
 addTime("timeToFirstInteractive");
+pageData["domContentFlushed"];
+var perfData = window.performance;
+var domContentFlushed = perfData.timing.timeToDOMContentFlushed - perfData.timing.fetchStart;
+return domContentFlushed;
+
 pageData["firstPaint"] = 0;
 // Try the standardized paint timing api
 try {


### PR DESCRIPTION
…oDOMContentFlushed

Attempts to address https://github.com/WPO-Foundation/wptagent/issues/229

This is **untested** in ```WebPageTest```, but the Custom Metrics JS snippet has been running in our private instance for a while now.

This is more of a working state for today's work, so I don't lose it (should work, but doesn't look pretty, nor in prevailing style, yet).

/cc @davehunt