### PR TITLE
Use pip list --format=freeze for compatibility across pip versions

### DIFF
--- a/wptagent.py
+++ b/wptagent.py
@@ -696,9 +696,9 @@ def upgrade_pip_modules():
         subprocess.call([sys.executable, '-m', 'pip', 'install', '--upgrade', 'pip'])
         run_elevated(sys.executable, '-m pip install --upgrade pip')
         out = subprocess.check_output([sys.executable, '-m', 'pip', 'list',
-                                       '--outdated'])
+                                       '--outdated', '--format', 'freeze'])
         for line in out.splitlines():
-            separator = line.find(' ')
+            separator = line.find('==')
             if separator > 0:
                 package = line[:separator]
                 subprocess.call([sys.executable, '-m', 'pip', 'install',


### PR DESCRIPTION
Our EC2 agents just started failing a few hours ago. I think it's due to a pip upgrade where the default format for `pip list` is now "columns", which wptagent.py does not parse correctly. I think wptagent.py knows how to parse the "legacy" format, but this doesn't seem to be available any more in pip 19.0, so I picked the "freeze" format which seems to be available in both 9.0 and 19.0 (the only two versions I have to test with).

Before merging this, would you be able to sanity check that this is a good change? I don't know a whole lot about the pip release cycle or the differences between versions.