### PR TITLE
Disable pip upgrades temporarily

### DIFF
--- a/wptagent.py
+++ b/wptagent.py
@@ -851,7 +851,10 @@ def main():
         logging.getLogger().addHandler(err_log)
 
     if options.ec2 or options.gce:
-        upgrade_pip_modules()
+        # Pip 19.0 was released on 23 January and seems to be causing issues.
+        # Skip upgrades until this is resolved.
+        # Ticket: https://github.com/pypa/pip/issues/6169
+        # upgrade_pip_modules()
     elif platform.system() == "Windows":
         # recovery for a busted Windows install
         try:

--- a/wptagent.py
+++ b/wptagent.py
@@ -854,7 +854,7 @@ def main():
         # Pip 19.0 was released on 23 January and seems to be causing issues.
         # Skip upgrades until this is resolved.
         # Ticket: https://github.com/pypa/pip/issues/6169
-        # upgrade_pip_modules()
+        print "Skipping pip module upgrade"
     elif platform.system() == "Windows":
         # recovery for a busted Windows install
         try:


### PR DESCRIPTION
So #235 didn't seem to fix anything. In the mean time, I wonder if it's better to use flat-out disable the pip upgrades? At least until there's a resolution to pypa/pip#6169.