### PR TITLE
Update key for Edge extensions to reflect Microsoft Webdriver changes

### DIFF
--- a/internal/microsoft_edge.py
+++ b/internal/microsoft_edge.py
@@ -126,7 +126,7 @@ class Edge(DesktopBrowser):
                     shutil.copy(src, extension_dir)
             except Exception:
                 pass
-        capabilities['extensionPaths'] = [extension_dir]
+        capabilities['ms:extensionPaths'] = [extension_dir]
         driver = webdriver.Edge(executable_path=self.path, capabilities=capabilities)
         return driver
 

--- a/internal/microsoft_edge.py
+++ b/internal/microsoft_edge.py
@@ -126,6 +126,7 @@ class Edge(DesktopBrowser):
                     shutil.copy(src, extension_dir)
             except Exception:
                 pass
+        capabilities['extensionPaths'] = [extension_dir]
         capabilities['ms:extensionPaths'] = [extension_dir]
         driver = webdriver.Edge(executable_path=self.path, capabilities=capabilities)
         return driver


### PR DESCRIPTION
There have been changes within the Microsoft Edge Webdriver. The Extension Paths are now set with a slightly different key (https://docs.microsoft.com/en-us/microsoft-edge/webdriver#w3c-webdriver). This pull request reflects these changes.