### PR TITLE
WIP: Support for cookies on iOS devices

### DIFF
--- a/internal/ios_device.py
+++ b/internal/ios_device.py
@@ -133,6 +133,13 @@ class iOSDevice(object):
             is_ok = True
         return is_ok
 
+    def set_cookie(self, url, name, value):
+        """Set a cookie"""
+        is_ok = False
+        if self.send_message("setcookie", data=url + ";" + name + ";" + value):
+            is_ok = True
+        return is_ok
+
     def show_orange(self):
         """Bring up the orange overlay"""
         is_ok = False

--- a/internal/safari_ios.py
+++ b/internal/safari_ios.py
@@ -1006,7 +1006,18 @@ class iWptBrowser(BaseBrowser):
         elif command['command'] == 'setuseragent':
             self.task['user_agent_string'] = command['target']
         elif command['command'] == 'setcookie':
-            pass
+            if 'target' in command and 'value' in command:
+                url = command['target'].strip()
+                cookie = command['value']
+                pos = cookie.find(';')
+                if pos > 0:
+                    cookie = cookie[:pos]
+                pos = cookie.find('=')
+                if pos > 0:
+                    name = cookie[:pos].strip()
+                    value = cookie[pos + 1:].strip()
+                    if len(name) and len(value) and len(url):
+                        self.ios.set_cookie(url, name, value)
         elif command['command'] == 'clearcache':
             self.ios.clear_cache()
         elif command['command'] == 'addheader':


### PR DESCRIPTION
_Work in progress_

This pull request adds support for setting cookies on iOS devices (> iOS 11) and works in conjunction with pull request WPO-Foundation/iWptBrowser#3 for iWptBrowser.
I think the part for WPT agent is fully functional but I'm having troubles to get cookies working in iWptBrowser (see pull request over there for more information).