### PR TITLE
Hook up plumbing for marionette's (Firefox) newly-exposed buildID metadata

### DIFF
--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -38,6 +38,7 @@ class Firefox(DesktopBrowser):
         self.connected = False
         self.start_offset = None
         self.browser_version = None
+        self.browser_build = None
         self.main_request_headers = None
         self.log_pos = {}
         self.log_level = 5
@@ -149,7 +150,7 @@ class Firefox(DesktopBrowser):
             if 'browserVersion' in self.marionette.session_capabilities:
                 self.browser_version = self.marionette.session_capabilities['browserVersion']
             if 'moz:buildID' in self.marionette.session_capabilities:
-                self.fx_buildID = self.marionette.session_capabilities['moz:buildID']
+                self.browser_version = self.marionette.session_capabilities['moz:buildID']
             self.marionette.navigate(self.start_page)
             time.sleep(0.5)
             self.wait_for_extension()

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -147,8 +147,8 @@ class Firefox(DesktopBrowser):
             self.extension_id = self.addons.install(extension_path, temp=True)
             logging.debug('Resizing browser to %dx%d', task['width'], task['height'])
             self.marionette.set_window_rect(x=0, y=0, height=task['height'], width=task['width'])
-            self.browser_version = self.marionette.session_capabilities.get['browserVersion']
-            self.browser_build = self.marionette.session_capabilities.get['moz:buildID']
+            self.browser_version = self.marionette.session_capabilities.get('browserVersion')
+            self.browser_build = self.marionette.session_capabilities.get('moz:buildID')
             self.marionette.navigate(self.start_page)
             time.sleep(0.5)
             self.wait_for_extension()

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -147,10 +147,8 @@ class Firefox(DesktopBrowser):
             self.extension_id = self.addons.install(extension_path, temp=True)
             logging.debug('Resizing browser to %dx%d', task['width'], task['height'])
             self.marionette.set_window_rect(x=0, y=0, height=task['height'], width=task['width'])
-            if 'browserVersion' in self.marionette.session_capabilities:
-                self.browser_version = self.marionette.session_capabilities['browserVersion']
-            if 'moz:buildID' in self.marionette.session_capabilities:
-                self.browser_build = self.marionette.session_capabilities['moz:buildID']
+            self.browser_version = self.marionette.session_capabilities.get['browserVersion']
+            self.browser_build = self.marionette.session_capabilities.get['moz:buildID']
             self.marionette.navigate(self.start_page)
             time.sleep(0.5)
             self.wait_for_extension()

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -150,7 +150,7 @@ class Firefox(DesktopBrowser):
             if 'browserVersion' in self.marionette.session_capabilities:
                 self.browser_version = self.marionette.session_capabilities['browserVersion']
             if 'moz:buildID' in self.marionette.session_capabilities:
-                self.browser_version = self.marionette.session_capabilities['moz:buildID']
+                self.browser_build = self.marionette.session_capabilities['moz:buildID']
             self.marionette.navigate(self.start_page)
             time.sleep(0.5)
             self.wait_for_extension()

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -148,6 +148,8 @@ class Firefox(DesktopBrowser):
             self.marionette.set_window_rect(x=0, y=0, height=task['height'], width=task['width'])
             if 'browserVersion' in self.marionette.session_capabilities:
                 self.browser_version = self.marionette.session_capabilities['browserVersion']
+            if 'moz:buildID' in self.marionette.session_capabilities:
+                self.fx_buildID = self.marionette.session_capabilities['moz:buildID']
             self.marionette.navigate(self.start_page)
             time.sleep(0.5)
             self.wait_for_extension()


### PR DESCRIPTION
Now that https://bugzilla.mozilla.org/show_bug.cgi?id=1525829 has landed, I'd like to be able to pull the Gecko/Firefox ```buildID``` from Marionette's Capabilities object (from the resulting test-runs' JSON file), and publish it alongside with the other metrics & metadata (```browser_version```, etc.)

@pmeenan would this be an acceptable, working change, for you?

If so, is ```fx_buildID``` fine, or would you prefer ```buildID```, ```firefox_buildID```, etc.?

/cc @davehunt @soulgalore 