### PR TITLE
Updates #246 with a Windows PoSh installer

### DIFF
--- a/internal/optimization_checks.py
+++ b/internal/optimization_checks.py
@@ -472,6 +472,7 @@ class OptimizationChecks(object):
                 from dns import resolver, reversename
                 dns_resolver = resolver.Resolver()
                 dns_resolver.timeout = 5
+                dns_resolver.lifetime = 5
                 # reverse-lookup the edge server
                 try:
                     addresses = dns_resolver.query(domain)
@@ -584,6 +585,7 @@ class OptimizationChecks(object):
         from dns import resolver, reversename
         dns_resolver = resolver.Resolver()
         dns_resolver.timeout = 1
+        dns_resolver.lifetime = 1
         provider = self.check_cdn_name(domain)
         # First do a CNAME check
         if provider is None:

--- a/windows_install.ps1
+++ b/windows_install.ps1
@@ -1,0 +1,11 @@
+﻿Install-WindowsFeature NET-Framework-Core
+Set-ExecutionPolicy Bypass -Scope Process -Force
+iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+iwr -Uri 'https://github.com/WPO-Foundation/wptagent/blob/master/windows_post_reboot.ps1' -OutFile- 'C:\post-reboot.ps1'
+refreshenv
+# Packages necessare for the wptagent Python tool to run
+cinst git vcpython27 imagemagick ffmpeg python2 winpcap -y /params "'/quiet'"
+# We need to reboot cause PATH needs updating, and refreshenv isn't foolproof. So, new startup task, new PS file, PS file runs once & deletes the sched task.
+refreshenv
+schtasks /create /tn WPTPostReboot /sc onstart /delay 0000:30 /rl highest /ru system /tr "powershell.exe -file C:\post-reboot.ps1"
+shutdown /r /f

--- a/windows_post_reboot.ps1
+++ b/windows_post_reboot.ps1
@@ -1,0 +1,6 @@
+pip install dnspython monotonic pillow psutil pypiwin32 requests ujson tornado marionette_driver selenium
+cd $env:USERPROFILE
+git clone https://github.com/WPO-Foundation/browser-install.git .\browser-install
+git clone https://github.com/WPO-Foundation/wptagent.git .\wptagent
+python .\browser-install\browser-install.py --all -vvvv
+schtasks /delete /tn WPTPostReboot /f


### PR DESCRIPTION
Adds a single command-line installers for Python, .NET 3.5 Framework, and the various dependencies (git etc.). Python dependencies are installed with pip post-reboot, then a git clone to download the browser installer and wptagent. I'm working out how to pass parameters to the post-reboot script to be able to register an instance with an ID and key.