### PR TITLE
Fix parsing of submitForm command to find form correctly

### DIFF
--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -806,7 +806,7 @@ class WebPageTest(object):
                                     attribute, attr_value)
                                 if command in ['click', 'sendclick']:
                                     script += '.click();'
-                                elif command == 'submitform' and value is not None:
+                                elif command == 'submitform' and attr_value is not None:
                                     script += '.submit();'
                                     record = True
                                 elif command in ['setvalue', 'selectvalue'] and value is not None:


### PR DESCRIPTION
The submitForm scripting command takes a single argument: the attribute
value and associated value used to identify the form in the DOM.
Currently, the logic for parsing this command attempts to use a
nonexistent (according to the syntax of the submitForm command) value to
identify the form instead of using the associated value of the
attribute. Fixed the parsing to use the appropriate value.