### PR TITLE
Add ability to customize fallback target for network check when using Android devices

### DIFF
--- a/internal/adb.py
+++ b/internal/adb.py
@@ -696,7 +696,7 @@ class Adb(object):
                             gateway = match.group(1)
                 if gateway is not None:
                     addresses.insert(0, gateway)
-                addresses.append('8.8.8.8')
+                addresses.append(self.options.ping)
                 for address in addresses:
                     if self.ping(address) is not None:
                         self.ping_address = address

--- a/wptagent.py
+++ b/wptagent.py
@@ -793,6 +793,9 @@ def main():
                         "    dhcp: Configure interface for DHCP\n"
                         "    <ip>/<network>,<gateway>,<dns1>,<dns2>: Static Address.  \n"
                         "        i.e. 192.168.0.8/24,192.168.0.1,8.8.8.8,8.8.4.4")
+    parser.add_argument('--ping', type=str, default='8.8.8.8',
+                        help="Set custom IP or domain to ping for checking network connection "
+                        "when using Android devices. Default is 8.8.8.8")
     parser.add_argument('--temperature', type=int, default=36,
                         help="set custom temperature treshold for device as int")
 


### PR DESCRIPTION
We encountered a problem, when we couldn't ping `8.8.8.8` from the attached Raspis. The network check then also failed for the Android device.
We couldn't figure out why we were unable to ping this IP. `8.8.4.4` was reachable, so we temporarily used this IP address.

Adding the possibility to customize the target, gives the ability to also use domain names, which would've prevented our problem. Is there a specific reason why we ping `8.8.8.8` instead e.g. `google.com`?