### PR TITLE
Use --init to avoid zombie processes.

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -34,5 +34,6 @@ Build the image first (from project root), load ifb and start it the container:
       -e LOCATION="docker-location" \
       -e NAME="Docker Test" \
       --cap-add=NET_ADMIN \
+      --init \
       wptagent
 


### PR DESCRIPTION
See #61 and #253.