### PR TITLE
Adding option to collect versions from available browsers using file …

### DIFF
--- a/internal/os_util.py
+++ b/internal/os_util.py
@@ -114,3 +114,15 @@ def get_free_disk_space():
         stat = os.statvfs(path)
         return float(stat.f_bavail * stat.f_frsize / 1024 / 1024) / 1024.0
 # pylint: enable=E1101
+
+def get_file_version(filename):
+    version = 0.0
+    try:
+        from win32api import GetFileVersionInfo, LOWORD, HIWORD
+        info = GetFileVersionInfo (filename, "\\")
+        ms = info['FileVersionMS']
+        ls = info['FileVersionLS']
+        version = '{0}.{1}.{2}.{3}'.format(HIWORD(ms), LOWORD(ms), HIWORD(ls), LOWORD(ls))
+    except:
+        pass
+    return version

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -361,7 +361,7 @@ class WebPageTest(object):
         else:
             subprocess.call(['sudo', 'reboot'])
 
-    def get_test(self):
+    def get_test(self, browsers):
         """Get a job from the server"""
         import requests
         proxies = {"http": None, "https": None}
@@ -402,10 +402,15 @@ class WebPageTest(object):
             uptime = self.get_uptime_minutes()
             if uptime is not None:
                 url += '&upminutes={0:d}'.format(uptime)
-            if 'browser_versions' in self.options and \
-                    len(self.options.browser_versions):
-                versions = ','.join(self.options.browser_versions)
-                url += '&browsers={0}'.format(versions)
+            if 'collectversion' in self.options and \
+                    self.options.collectversion:
+                versions = []
+                for name in browsers.keys():
+                    if 'version' in browsers[name]:
+                        versions.append('{0}:{1}'.format(name, \
+                                browsers[name]['version']))
+                browsers = ','.join(versions)
+                url += '&browsers=' + urllib.quote_plus(browsers)
             logging.info("Checking for work: %s", url)
             try:
                 response = self.session.get(url, timeout=30, proxies=proxies)

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -402,6 +402,10 @@ class WebPageTest(object):
             uptime = self.get_uptime_minutes()
             if uptime is not None:
                 url += '&upminutes={0:d}'.format(uptime)
+            if 'browser_versions' in self.options and \
+                    len(self.options.browser_versions):
+                versions = ','.join(self.options.browser_versions)
+                url += '&browsers={0}'.format(versions)
             logging.info("Checking for work: %s", url)
             try:
                 response = self.session.get(url, timeout=30, proxies=proxies)

--- a/wptagent.py
+++ b/wptagent.py
@@ -734,6 +734,18 @@ def upgrade_pip_modules():
         pass
 
 
+def get_browser_versions(browsers):
+    """Get the version of the available browsers"""
+    versions = []
+    from internal.os_util import get_file_version
+    for browser in browsers:
+        if 'exe' in browsers[browser] and \
+                os.path.isfile(browsers[browser]['exe']):
+            exe = browsers[browser]['exe']
+            versions.append('{0}:{1}'.format(browser, get_file_version(exe)))
+    return versions
+
+
 def main():
     """Startup and initialization"""
     import argparse
@@ -759,6 +771,8 @@ def main():
                         help="Log critical errors to the given file.")
     parser.add_argument('--noidle', action='store_true', default=False,
                         help="Do not wait for system idle at startup.")
+    parser.add_argument('--collectversion', action='store_true', default=False,
+                        help="Collection browser versions and submit to controller.")                        
 
     # Video capture/display settings
     parser.add_argument('--xvfb', action='store_true', default=False,
@@ -900,6 +914,11 @@ def main():
         if len(browsers) == 0:
             print "No browsers configured. Check that browsers.ini is present and correct."
             exit(1)
+
+    if options.collectversion and \
+            platform.system() == "Windows":
+        versions = get_browser_versions(browsers)
+        options.browser_versions = versions
 
     agent = WPTAgent(options, browsers)
     if agent.startup():

--- a/wptagent.py
+++ b/wptagent.py
@@ -95,7 +95,7 @@ class WPTAgent(object):
                     logging.error("Message server not responding, exiting")
                     break
                 if self.browsers.is_ready():
-                    self.job = self.wpt.get_test()
+                    self.job = self.wpt.get_test(self.browsers.browsers)
                     if self.job is not None:
                         self.job['image_magick'] = self.image_magick
                         self.job['message_server'] = message_server
@@ -736,14 +736,12 @@ def upgrade_pip_modules():
 
 def get_browser_versions(browsers):
     """Get the version of the available browsers"""
-    versions = []
     from internal.os_util import get_file_version
     for browser in browsers:
         if 'exe' in browsers[browser] and \
                 os.path.isfile(browsers[browser]['exe']):
             exe = browsers[browser]['exe']
-            versions.append('{0}:{1}'.format(browser, get_file_version(exe)))
-    return versions
+            browsers[browser]['version'] = get_file_version(exe)
 
 
 def main():
@@ -915,10 +913,8 @@ def main():
             print "No browsers configured. Check that browsers.ini is present and correct."
             exit(1)
 
-    if options.collectversion and \
-            platform.system() == "Windows":
-        versions = get_browser_versions(browsers)
-        options.browser_versions = versions
+    if options.collectversion and platform.system() == "Windows":
+        get_browser_versions(browsers)
 
     agent = WPTAgent(options, browsers)
     if agent.startup():


### PR DESCRIPTION
…versions for windows agents

Adding a new startup option to wptagent.py:
  --collectversion

In windows agents, this will enable collecting the browser versions using the info available in browser exes and submit them back to the controller.