### PR TITLE
Write long tasks found from toplevel category events to results file.

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -190,7 +190,7 @@ class DevTools(object):
                 if 'type' in target and 'targetId' in target:
                     if target['type'] == 'service_worker':
                         self.send_command('Target.attachToTarget', {'targetId': target['targetId']},
-                                          wait=True)
+                                           wait=True)
 
     def close(self, close_tab=True):
         """Close the dev tools connection"""

--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -190,7 +190,7 @@ class DevTools(object):
                 if 'type' in target and 'targetId' in target:
                     if target['type'] == 'service_worker':
                         self.send_command('Target.attachToTarget', {'targetId': target['targetId']},
-                                      wait=True)
+                                          wait=True)
 
     def close(self, close_tab=True):
         """Close the dev tools connection"""
@@ -839,7 +839,7 @@ class DevTools(object):
     def clear_cache(self):
         """Clear the browser cache"""
         self.send_command('Network.clearBrowserCache', {}, wait=True)
-  
+
     def disable_cache(self, disable):
         """Disable the browser cache"""
         self.send_command('Network.setCacheDisabled', {'cacheDisabled': disable}, wait=True)
@@ -1242,7 +1242,7 @@ class DevToolsClient(WebSocketClient):
             self.trace_parser.WriteInteractive(self.path_base + '_interactive.json.gz')
             self.trace_parser.WriteNetlog(self.path_base + '_netlog_requests.json.gz')
             self.trace_parser.WriteV8Stats(self.path_base + '_v8stats.json.gz')
-            self.trace_parser.WriteLongTasks(self.path_base+'_long_tasks.json.gz')
+            self.trace_parser.WriteLongTasks(self.path_base + '_long_tasks.json.gz')
             elapsed = monotonic.monotonic() - start
             logging.debug("Done processing the trace events: %0.3fs", elapsed)
         self.trace_parser = None

--- a/internal/support/trace_parser.py
+++ b/internal/support/trace_parser.py
@@ -387,11 +387,16 @@ class Trace():
                     self.timeline_events.append(e)
 
     def ProcessTopLevelEventForLongTasks(self, trace_event):       
-        if trace_event['dur'] > 50000 and trace_event['name'] == 'ThreadControllerImpl::RunTask' and \
-            self.cpu['main_thread'] is not None and \
-            '{0}:{1}'.format(trace_event['pid'],trace_event['tid']) == self.cpu['main_thread']:
-            self.long_tasks.append(
-                [int(math.floor(trace_event['ts'] - self.start_time)/1000),int(math.floor(trace_event['dur']/1000))])
+        try:
+            if 'dur' in trace_event and trace_event['dur'] > 50000 and \
+                trace_event['name'] == 'ThreadControllerImpl::RunTask' and \
+                self.cpu['main_thread'] is not None and \
+                '{0}:{1}'.format(trace_event['pid'],trace_event['tid']) == self.cpu['main_thread']:
+                self.long_tasks.append(
+                    [int(math.floor(trace_event['ts'] - self.start_time)/1000),int(math.floor(trace_event['dur']/1000))])
+        except Exception :
+            pass    
+
           
     def ProcessOldTimelineEvent(self, event, type):
         e = None


### PR DESCRIPTION
Long Tasks on the browser main thread can be found by processing trace events with name "ThreadControllerImpl::RunTask" having duration > 50ms. This change writes the results of these long tasks to a results file '<pathtemplate>_long_tasks.gz'. This will be used to calculate TotalLongTaskTime or other Long Tasks based metrics in post processing.

Since these task related events belong to 'toplevel' category , we include it by default when timeline or trace option is selected. We do not however save these toplevel events to the trace/timeline files unless user has explicitly added 'toplevel' category to reduce the trace sizes.