### PR TITLE
Extend last interactive window to the end of the run

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -447,7 +447,7 @@ class DevTools(object):
                                                   self.start_timestamp, keep_timeline)
             self.send_command('Tracing.end', {})
 
-    def collect_trace(self):
+    def collect_trace(self, run_time):
         """Stop tracing and collect the results"""
         if self.trace_enabled:
             self.trace_enabled = False
@@ -474,7 +474,7 @@ class DevTools(object):
                             no_message_count += 1
                             time.sleep(1)
                             pass
-                self.websocket.stop_processing_trace()
+                self.websocket.stop_processing_trace(run_time)
             except Exception:
                 pass
             elapsed = monotonic.monotonic() - start
@@ -1206,7 +1206,7 @@ class DevToolsClient(WebSocketClient):
         self.video_viewport = None
         self.keep_timeline = keep_timeline
 
-    def stop_processing_trace(self):
+    def stop_processing_trace(self, run_time):
         """All done"""
         if self.pending_image is not None and self.last_image is not None and\
                 self.pending_image["image"] != self.last_image["image"]:
@@ -1228,7 +1228,7 @@ class DevToolsClient(WebSocketClient):
             logging.debug("Post-Processing the trace netlog events")
             self.trace_parser.post_process_netlog_events()
             logging.debug("Processing the trace timeline events")
-            self.trace_parser.ProcessTimelineEvents()
+            self.trace_parser.ProcessTimelineEvents(run_time)
             self.trace_parser.WriteUserTiming(self.path_base + '_user_timing.json.gz')
             self.trace_parser.WriteCPUSlices(self.path_base + '_timeline_cpu.json.gz')
             self.trace_parser.WriteScriptTimings(self.path_base + '_script_timing.json.gz')

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -172,7 +172,10 @@ class DevtoolsBrowser(object):
     def on_stop_recording(self, task):
         """Stop recording"""
         if self.devtools is not None:
-            self.devtools.collect_trace()
+            run_time = 0
+            if 'run_start_time' in task and 'run_end_time' in task:
+                run_time = task['run_end_time'] - task['run_start_time']
+            self.devtools.collect_trace(run_time)
             if self.devtools_screenshot:
                 if self.job['pngScreenShot']:
                     screen_shot = os.path.join(task['dir'],
@@ -205,6 +208,7 @@ class DevtoolsBrowser(object):
                 self.process_command(command)
                 if command['record']:
                     self.devtools.wait_for_page_load()
+                    task['run_end_time'] = monotonic.monotonic()
                     if not task['combine_steps'] or not len(task['script']):
                         self.on_stop_capture(task)
                         self.on_stop_recording(task)

--- a/internal/support/trace_parser.py
+++ b/internal/support/trace_parser.py
@@ -476,8 +476,14 @@ class Trace():
                     len(self.interactive):
                 run_time_ms = int(math.floor(run_time * 1000.0))
                 last_window = self.interactive.pop()
-                last_window[1] = run_time_ms
-                self.interactive.append(last_window)
+                if last_window[1] != self.cpu['total_usecs']:
+                    new_window = [int(math.ceil(self.cpu['total_usecs'] / 1000.0)),
+                                  int(math.floor(run_time_ms /1000.0))]
+                    self.interactive.append(last_window)    
+                    self.interactive.append(new_window)
+                else:
+                    last_window[1] = run_time_ms
+                    self.interactive.append(last_window)
 
             # Go through all of the fractional times and convert the float
             # fractional times to integer usecs

--- a/internal/support/trace_parser.py
+++ b/internal/support/trace_parser.py
@@ -436,7 +436,7 @@ class Trace():
                         e['c'].append(c)
         return e
 
-    def ProcessTimelineEvents(self):
+    def ProcessTimelineEvents(self, run_time = 0):
         if len(self.timeline_events) and self.end_time > self.start_time:
             # Figure out how big each slice should be in usecs. Size it to a
             # power of 10 where we have at least 2000 slices
@@ -468,6 +468,16 @@ class Trace():
                     self.interactive_start > 500000:
                 self.interactive.append([int(math.ceil(self.interactive_start / 1000.0)),
                                          int(math.floor(self.interactive_end / 1000.0))])
+
+            # Extend last interactive window to the end of the run
+            # Assuming that if there are no events past the last interactive window
+            # then the page was interactive for that time
+            if self.cpu['total_usecs'] == self.interactive_end and run_time > 0 and \
+                    len(self.interactive):
+                run_time_ms = int(math.floor(run_time * 1000.0))
+                last_window = self.interactive.pop()
+                last_window[1] = run_time_ms
+                self.interactive.append(last_window)
 
             # Go through all of the fractional times and convert the float
             # fractional times to integer usecs


### PR DESCRIPTION
Currently the last interactive window ends at timestamp of the last timeline event.  For tests and pages which finish relatively quickly, this results in First CPU Idle (f.k.a. firstInteractive) being null.  

For this test:
https://www.webpagetest.org/result/190913_ZG_1a1fb09c7c72a2d51947801c0a99b9b2/

The test ran up to ~6.6s, but the last interactive window is only from 1405 - 3620, which disqualifies it from getting First CPU Idle.  

If there were no timeline events after the last interactive window end, I think we can assume that the page was interactive until the end of the test, so we should extend this interactive window to that time.