### PR TITLE
add lighthouseScreenshots option

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -486,6 +486,8 @@ class DevtoolsBrowser(object):
                        '--output-path', '"{0}"'.format(output_path)]
             if self.job['keep_lighthouse_trace']:
                 command.append('--save-assets')
+            if not self.job['keep_lighthouse_screenshots']:
+                command.extend(['--skip-audits', 'screenshot-thumbnails'])
             if self.options.android or 'mobile' not in self.job or not self.job['mobile']:
                 command.extend(['--emulated-form-factor', 'none'])
                 if 'user_agent_string' in self.job:
@@ -539,22 +541,10 @@ class DevtoolsBrowser(object):
                 except Exception:
                     pass
             if os.path.isfile(json_file):
-                # Remove the raw screenshots if they were stored with the file
                 lh_report = None
                 with open(json_file, 'rb') as f_in:
                     lh_report = json.load(f_in)
-                modified = False
-                if lh_report is not None and 'audits' in lh_report:
-                    if 'screenshots' in lh_report['audits']:
-                        del lh_report['audits']['screenshots']
-                        modified = True
-                    if 'screenshot-thumbnails' in lh_report['audits']:
-                        del lh_report['audits']['screenshot-thumbnails']
-                        modified = True
-                if modified:
-                    with gzip.open(json_gzip, 'wb', 7) as f_out:
-                        json.dump(lh_report, f_out)
-                else:
+                if lh_report is None or 'audits' not in lh_report:
                     with open(json_file, 'rb') as f_in:
                         with gzip.open(json_gzip, 'wb', 7) as f_out:
                             shutil.copyfileobj(f_in, f_out)

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -605,21 +605,6 @@ class DevtoolsBrowser(object):
                     audits_gzip = os.path.join(task['dir'], 'lighthouse_audits.json.gz')
                     with gzip.open(audits_gzip, 'wb', 7) as f_out:
                         json.dump(audits, f_out)
-            if os.path.isfile(html_file):
-                # Remove the raw screenshots if they were stored with the file
-                with open(html_file, 'rb') as f_in:
-                    lh_report = f_in.read()
-                    start = lh_report.find('\n    &quot;screenshots')
-                    if start >= 0:
-                        end = lh_report.find('\n    },', start)
-                        if end >= 0:
-                            lh_report = lh_report[:start] + lh_report[end + 7:]
-                    with gzip.open(html_gzip, 'wb', 7) as f_out:
-                        f_out.write(lh_report)
-                try:
-                    os.remove(html_file)
-                except Exception:
-                    pass
 
     def wappalyzer_detect(self, task, request_headers):
         """Run the wappalyzer detection"""

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -459,6 +459,8 @@ class WebPageTest(object):
                         job['lighthouse'] = 1
                     job['keep_lighthouse_trace'] = \
                         bool('lighthouseTrace' in job and job['lighthouseTrace'])
+                    job['keep_lighthouse_screenshots'] = \
+                        bool(job['lighthouseScreenshots']) if 'lighthouseScreenshots' in job else False
                     job['lighthouse_throttle'] = \
                         bool('lighthouseThrottle' in job and job['lighthouseThrottle'])
                     job['video'] = bool('Capture Video' in job and job['Capture Video'])


### PR DESCRIPTION
1. introduce `lighthouseScreenshots` option to keep screenshot thumbnails in the JSON
1. use `--skip-audits` to trim screenshot data

I didn't run any of these locally (seems daunting ...). If these changes seem suspect, LMK and I'll spent some time on that.