### PR TITLE
add '--channel wpt' to lighthouse run

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -475,6 +475,7 @@ class DevtoolsBrowser(object):
             time_limit = min(int(task['time_limit']), 80)
             command = ['lighthouse',
                        '"{0}"'.format(self.job['url']),
+                       '--channel', 'wpt',
                        '--disable-network-throttling',
                        '--disable-cpu-throttling',
                        '--throttling-method', 'provided',


### PR DESCRIPTION
`channel` is for denoting the service that runs Lighthouse. We (lighthouse) use it to differentiate `devtools`, `extension`, and `lr` (hosted LH service) execution environments.

This change sets `channel` to `wpt`. There are no changes in behavior, just an extra property in the returned LHR.