### PR TITLE
fix saving lighthouse json file

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -545,10 +545,10 @@ class DevtoolsBrowser(object):
                 lh_report = None
                 with open(json_file, 'rb') as f_in:
                     lh_report = json.load(f_in)
-                if lh_report is None or 'audits' not in lh_report:
-                    with open(json_file, 'rb') as f_in:
-                        with gzip.open(json_gzip, 'wb', 7) as f_out:
-                            shutil.copyfileobj(f_in, f_out)
+
+                with open(json_file, 'rb') as f_in:
+                    with gzip.open(json_gzip, 'wb', 7) as f_out:
+                        shutil.copyfileobj(f_in, f_out)
                 try:
                     os.remove(json_file)
                 except Exception:


### PR DESCRIPTION
I messed up the logic here: https://github.com/WPO-Foundation/wptagent/commit/3c507da1e1216be6c41c5ee916d0cdbe37acdc89#diff-e2637cf67a17146071cc640a5af4bbecR547

No json is being saved anymore. this should fix it.