### PR TITLE
Enable CPU throttling for non-mobile tests

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -112,12 +112,12 @@ class DevtoolsBrowser(object):
                 self.devtools.send_command("Emulation.setScrollbarsHidden",
                                            {"hidden": True},
                                            wait=True)
-                if (task['running_lighthouse'] or not self.options.throttle) and 'throttle_cpu' in self.job:
-                    logging.debug('CPU Throttle target: %0.3fx', self.job['throttle_cpu'])
-                    if self.job['throttle_cpu'] > 1:
-                        self.devtools.send_command("Emulation.setCPUThrottlingRate",
-                                                   {"rate": self.job['throttle_cpu']},
-                                                   wait=True)
+            if (task['running_lighthouse'] or not self.options.throttle) and 'throttle_cpu' in self.job:
+                logging.debug('CPU Throttle target: %0.3fx', self.job['throttle_cpu'])
+                if self.job['throttle_cpu'] > 1:
+                    self.devtools.send_command("Emulation.setCPUThrottlingRate",
+                                                {"rate": self.job['throttle_cpu']},
+                                                wait=True)
 
             # Location
             if 'lat' in self.job and 'lng' in self.job:


### PR DESCRIPTION
I just noticed that CPU throttling only applies when the `mobile` parameter is enabled. Is this intentional? If not, this PR allows CPU throttling to apply on non-mobile tests. 