### PR TITLE
Separate CPU throttling for lighthouse

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -112,12 +112,12 @@ class DevtoolsBrowser(object):
                 self.devtools.send_command("Emulation.setScrollbarsHidden",
                                            {"hidden": True},
                                            wait=True)
-                if (task['running_lighthouse'] or not self.options.throttle) and 'throttle_cpu' in self.job:
-                    logging.debug('CPU Throttle target: %0.3fx', self.job['throttle_cpu'])
-                    if self.job['throttle_cpu'] > 1:
-                        self.devtools.send_command("Emulation.setCPUThrottlingRate",
-                                                   {"rate": self.job['throttle_cpu']},
-                                                   wait=True)
+            if (task['running_lighthouse'] or not self.options.throttle) and 'throttle_cpu' in self.job:
+                logging.debug('CPU Throttle target: %0.3fx', self.job['throttle_cpu'])
+                if self.job['throttle_cpu'] > 1:
+                    self.devtools.send_command("Emulation.setCPUThrottlingRate",
+                                                {"rate": self.job['throttle_cpu']},
+                                                wait=True)
 
             # Location
             if 'lat' in self.job and 'lng' in self.job:

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -112,11 +112,14 @@ class DevtoolsBrowser(object):
                 self.devtools.send_command("Emulation.setScrollbarsHidden",
                                            {"hidden": True},
                                            wait=True)
-            if (task['running_lighthouse'] or not self.options.throttle) and 'throttle_cpu' in self.job:
-                logging.debug('CPU Throttle target: %0.3fx', self.job['throttle_cpu'])
-                if self.job['throttle_cpu'] > 1:
+            if (task['running_lighthouse'] or not self.options.throttle) and ('throttle_cpu' in self.job or 'throttle_cpu_lighthouse' in self.job):
+                throttle_cpu = self.job['throttle_cpu']
+                if task['running_lighthouse'] and 'throttle_cpu_lighthouse' in self.job:
+                    throttle_cpu = self.job['throttle_cpu_lighthouse']
+                logging.debug('CPU Throttle target: %0.3fx', throttle_cpu)
+                if throttle_cpu > 1:
                     self.devtools.send_command("Emulation.setCPUThrottlingRate",
-                                                {"rate": self.job['throttle_cpu']},
+                                                {"rate": throttle_cpu},
                                                 wait=True)
 
             # Location

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -476,6 +476,12 @@ class WebPageTest(object):
                             throttle *= self.cpu_scale_multiplier
                         job['throttle_cpu_requested'] = job['throttle_cpu']
                         job['throttle_cpu'] = throttle
+                    if 'throttle_cpu_lighthouse' in job:
+                        lighthouse_throttle = float(re.search(r'\d+\.?\d*', str(job['throttle_cpu_lighthouse'])).group())
+                        if 'bypass_cpu_normalization' not in job or not job['bypass_cpu_normalization']:
+                            lighthouse_throttle *= self.cpu_scale_multiplier
+                        job['throttle_cpu_lighthouse_requested'] = job['throttle_cpu_lighthouse']
+                        job['throttle_cpu_lighthouse'] = lighthouse_throttle
                 if job is None and len(locations) > 0:
                     location = str(locations.pop(0))
                     retry = True


### PR DESCRIPTION
This patch adds a `throttle_cpu_lighthouse` parameter which would allow testing with separate throttling values for the "main" test and the Lighthouse test.

The context around this is that at SpeedCurve we run LH as part of the main test run, which might have no CPU throttling (e.g. an emulated iPhone X). But in order to maintain consistent LH scores, we'd like to set the CPU throttling for LH to be the same value regardless of the main test throttling.

This was branched from #298. I can submit a separate patch if that PR is invalid.