### PR TITLE
Handling non-ascii characters in headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,8 @@ RUN apt-get update && \
     xvfbwrapper \
     brotli \
     'fonttools>=3.44.0,<4.0.0' \
-    marionette_driver
+    marionette_driver \
+    future
 
 COPY wptagent.py /wptagent/wptagent.py
 COPY internal /wptagent/internal

--- a/centos_install.sh
+++ b/centos_install.sh
@@ -23,7 +23,7 @@ do
 done
 sudo dbus-uuidgen --ensure
 sudo pip install --upgrade pip
-until sudo pip install dnspython monotonic pillow psutil requests ujson tornado xvfbwrapper marionette_driver
+until sudo pip install dnspython monotonic pillow psutil requests ujson tornado xvfbwrapper marionette_driver future
 do
     sleep 1
 done

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ wptagent currently supports Windows, Linux and OSX for desktop browsers as well 
 * cgroup-tools (Linux only if mobile CPU emulation is desired)
 * traceroute (Mac and Linux)
 * Debian:
-    * ```sudo apt-get install -y python2.7 python-pip imagemagick ffmpeg xvfb dbus-x11 cgroup-tools traceroute && sudo pip install dnspython monotonic pillow psutil requests ujson tornado xvfbwrapper marionette_driver```
+    * ```sudo apt-get install -y python2.7 python-pip imagemagick ffmpeg xvfb dbus-x11 cgroup-tools traceroute && sudo pip install dnspython monotonic pillow psutil requests ujson tornado xvfbwrapper marionette_driver future```
 * Chrome Browser
     * Linux stable, beta and unstable channels on Ubuntu/Debian:
         * ```wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -```

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,6 +12,7 @@ wptagent currently supports Windows, Linux and OSX for desktop browsers as well 
     * requests
     * ujson
     * tornado
+    * future
     * xvfbwrapper (Linux only)
     * bind9utils (Linux only, for rndc)
     * marionette_driver (Firefox)

--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -21,9 +21,9 @@ import os
 import re
 import sys
 import time
+from builtins import str
 if (sys.version_info > (3, 0)):
     from urllib.parse import urlsplit # pylint: disable=import-error
-    unicode = str
     GZIP_TEXT = 'wt'
     GZIP_READ_TEXT = 'rt'
 else:
@@ -87,7 +87,7 @@ class DevToolsParser(object):
                     self.make_utf8(entry)
                 elif isinstance(entry, str):
                     try:
-                        data[key] = unicode(entry)
+                        data[key] = str(entry, 'utf-8')
                     except Exception:
                         logging.exception('Error making utf8')
         elif isinstance(data, list):
@@ -97,7 +97,7 @@ class DevToolsParser(object):
                     self.make_utf8(entry)
                 elif isinstance(entry, str):
                     try:
-                        data[key] = unicode(entry)
+                        data[key] = str(entry, 'utf-8')
                     except Exception:
                         logging.exception('Error making utf8')
 
@@ -568,7 +568,7 @@ class DevToolsParser(object):
                 request['headers'] = {'request': [], 'response': []}
                 if 'response' in raw_request and 'requestHeadersText' in raw_request['response']:
                     for line in raw_request['response']['requestHeadersText'].splitlines():
-                        line = unicode(line.encode('utf-8')).strip()
+                        line = str(line.encode('utf-8'), 'utf-8').strip()
                         if len(line):
                             request['headers']['request'].append(line)
                 elif 'response' in raw_request and 'requestHeaders' in raw_request['response']:
@@ -576,8 +576,8 @@ class DevToolsParser(object):
                         for value in raw_request['response']['requestHeaders'][key].splitlines():
                             try:
                                 request['headers']['request'].append(\
-                                    u'{0}: {1}'.format(unicode(key.encode('utf-8')),
-                                                       unicode(value.encode('utf-8')).strip()))
+                                    u'{0}: {1}'.format(str(key.encode('utf-8'), 'utf-8'),
+                                                       str(value.encode('utf-8'), 'utf-8').strip()))
                             except Exception:
                                 logging.exception('Error processing response headers')
                 elif 'headers' in raw_request:
@@ -585,22 +585,25 @@ class DevToolsParser(object):
                         for value in raw_request['headers'][key].splitlines():
                             try:
                                 request['headers']['request'].append(\
-                                    u'{0}: {1}'.format(unicode(key.encode('utf-8')),
-                                                       unicode(value.encode('utf-8')).strip()))
+                                    u'{0}: {1}'.format(str(key.encode('utf-8'), 'utf-8'),
+                                                       str(value.encode('utf-8'), 'utf-8').strip()))
                             except Exception:
                                 logging.exception('Error processing request headers')
                 if 'response' in raw_request and 'headersText' in raw_request['response']:
                     for line in raw_request['response']['headersText'].splitlines():
-                        line = unicode(line.encode('utf-8')).strip()
-                        if len(line):
-                            request['headers']['response'].append(line)
+                        try:
+                            line = str(line.encode('utf-8'), 'utf-8').strip()
+                            if len(line):
+                                request['headers']['response'].append(line)
+                        except Exception:
+                            logging.exception('Error processing request headers')
                 elif 'response' in raw_request and 'headers' in raw_request['response']:
                     for key in raw_request['response']['headers']:
                         for value in raw_request['response']['headers'][key].splitlines():
                             try:
                                 request['headers']['response'].append(\
-                                    u'{0}: {1}'.format(unicode(key.encode('utf-8')),
-                                                       unicode(value.encode('utf-8')).strip()))
+                                    u'{0}: {1}'.format(str(key.encode('utf-8'), 'utf-8'),
+                                                       str(value.encode('utf-8'), 'utf-8').strip()))
                             except Exception:
                                 logging.exception('Error processing response headers')
                 request['bytesOut'] = len("\r\n".join(str(request['headers']['request'])))

--- a/ubuntu_install.sh
+++ b/ubuntu_install.sh
@@ -10,7 +10,7 @@ done
 # Unavailable on Ubuntu 18.04 but needed on earlier releases
 sudo apt-get install -y python-software-properties
 sudo dbus-uuidgen --ensure
-until sudo pip install dnspython monotonic pillow psutil requests git+git://github.com/marshallpierce/ultrajson.git@v1.35-gentoo-fixes tornado wsaccel xvfbwrapper brotli marionette_driver
+until sudo pip install dnspython monotonic pillow psutil requests git+git://github.com/marshallpierce/ultrajson.git@v1.35-gentoo-fixes tornado wsaccel xvfbwrapper brotli marionette_driver future
 do
     sleep 1
 done
@@ -26,7 +26,7 @@ do
 done
 sudo npm update -g
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' 
+sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 sudo add-apt-repository -y ppa:ubuntu-mozilla-daily/ppa
 sudo add-apt-repository -y ppa:mozillateam/ppa
 sudo apt-get update

--- a/windows_post_reboot.ps1
+++ b/windows_post_reboot.ps1
@@ -1,4 +1,4 @@
-pip install dnspython monotonic pillow psutil pypiwin32 requests ujson tornado marionette_driver selenium
+pip install dnspython monotonic pillow psutil pypiwin32 requests ujson tornado marionette_driver selenium future
 cd $env:USERPROFILE
 git clone https://github.com/WPO-Foundation/browser-install.git .\browser-install
 git clone https://github.com/WPO-Foundation/wptagent.git .\wptagent

--- a/wptagent.py
+++ b/wptagent.py
@@ -376,7 +376,7 @@ class WPTAgent(object):
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             _, err = proc.communicate()
             for line in err.splitlines():
-                matches = re.search(r'\[(\d+)\] Capture screen', line)
+                matches = re.search(r'\[(\d+)\] Capture screen', line.decode('utf-8'))
                 if matches:
                     self.capture_display = matches.group(1)
                     break

--- a/wptagent.py
+++ b/wptagent.py
@@ -311,6 +311,7 @@ class WPTAgent(object):
         ret = self.requires('PIL', 'pillow') and ret
         ret = self.requires('psutil') and ret
         ret = self.requires('requests') and ret
+        ret = self.requires('future') and ret
         if not self.options.android and not self.options.iOS:
             ret = self.requires('tornado') and ret
         # Windows-specific imports
@@ -840,7 +841,7 @@ def main():
     parser.add_argument('--noidle', action='store_true', default=False,
                         help="Do not wait for system idle at startup.")
     parser.add_argument('--collectversion', action='store_true', default=False,
-                        help="Collection browser versions and submit to controller.")                        
+                        help="Collection browser versions and submit to controller.")
 
     # Video capture/display settings
     parser.add_argument('--xvfb', action='store_true', default=False,


### PR DESCRIPTION
Hi Pat,

we've encountered a cookie during testing which contained non-ascii characters (german umlaut).
Unfortunately the world outside doesn't care about conventions: [Accepted cookie value characters as described at MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives) 😉
With this pull request we handle this by firstly catching the thrown exception and secondly we propose to use the python `str()` object from [Python Future](http://python-future.org/str_object.html) instead of overwriting the `unicode` object by ourselves.

We couldn't create a reproducable example (our umlaut is from a customer) that we could show with the official WPT instance. Are you running your agents with Python 3 now?
We've build a simple flask example app which delivers a header with an umlaut: https://wptagent-encoding.herokuapp.com/
With our agents (running with Python 2) we got different behaviors:

- **Chrome** looses the umlaut entirely (see `Set-Cookie: Mnchen` which should read `München`):
![image](https://user-images.githubusercontent.com/25281769/72733322-ea95ae80-3b97-11ea-81dd-936069c42779.png)

- **Firefox** seems to have a similar problem:
![image](https://user-images.githubusercontent.com/25281769/72733215-ae624e00-3b97-11ea-9101-d6ecfd372b67.png)

If the proposed way of using `str()` from Python Future seems good to you, we're happy to fix the Firefox problem in the same way. We wanted to have a chat with you about this issue before we dig deeper into the code to find all the places where `unicode` is used.