### PR TITLE
Add ZEIT Smart CDN to Optimization Checks

### DIFF
--- a/internal/optimization_checks.py
+++ b/internal/optimization_checks.py
@@ -216,6 +216,7 @@ class OptimizationChecks(object):
                       '.yimg.',
                       '.yahooapis.com'],
             'Yottaa': ['.yottaa.net'],
+            'ZEIT Smart CDN': ['.zeit.co'],
             'Zenedge': ['.zenedge.net']
         }
         self.cdn_headers = {
@@ -282,6 +283,7 @@ class OptimizationChecks(object):
             'XLabs Security': [{'x-cdn': 'XLabs Security'}],
             'Yunjiasu': [{'Server': 'yunjiasu'}],
             'Zenedge': [{'X-Cdn': 'Zenedge'}],
+            'ZEIT Smart CDN': [{'Server': 'now'}],
             'Zycada Networks': [{'X-Zy-Server': ''}]
         }
         # spell-checker: enable


### PR DESCRIPTION
We want https://zeit.co/smart-cdn to be detected as a CDN

The CDN is enabled automatically for all ZEIT Now deployments and can be detected by the header: `Server: now`:

```
$ curl https://zeit.co -I | grep server
server: now
```