### PR TITLE
Don't try to process v8stats file if it's None

### DIFF
--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -1341,7 +1341,7 @@ class DevToolsParser(object):
         """Add the v8 stats to the page data"""
         try:
             page_data = self.result['pageData']
-            if os.path.isfile(self.v8_stats):
+            if self.v8_stats is not None and os.path.isfile(self.v8_stats):
                 _, ext = os.path.splitext(self.v8_stats)
                 if ext.lower() == '.gz':
                     f_in = gzip.open(self.v8_stats, GZIP_READ_TEXT)


### PR DESCRIPTION
Handles an exception where devtools_parser tries to stat a "None" v8stats file. This exception [1] occurs when devtools_browser sets the v8stats to None because the v8stats file doesn't exist. Devtools_parser assumes if v8stats *exists* in the options dictionary it is a valid file, but doesn't check to see if the value is "None" before trying to stat the file.
[1]
Traceback (most recent call last):
  File "c:\users\administrator\wptagent\internal\support\devtools_parser.py", line 1344, in process_v8_stats
    if os.path.isfile(self.v8_stats):
  File "C:\Python27\lib\genericpath.py", line 37, in isfile
    st = os.stat(path)
TypeError: coercing to Unicode: need string or buffer, NoneType found