### PR TITLE
Ignore unicode errors in lighthouse output

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -468,11 +468,11 @@ class DevtoolsBrowser(object):
         proc = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE)
         for line in iter(proc.stderr.readline, b''):
             try:
-                line = unicode(line)
+                line = unicode(line,errors='ignore')
                 logging.debug(line.rstrip())
                 self.task['lighthouse_log'] += line
             except Exception:
-                logging.exception('Error recording lighthouse log line')
+                logging.exception('Error recording lighthouse log line %s', line.rstrip())
         proc.communicate()
 
     def run_lighthouse_test(self, task):


### PR DESCRIPTION
Lighthouse is including unicode characters in some of the log lines, like an ellipsis. As a result, UnicodeDecodeErrors are thrown when lines with those unicode characters try to store themselves in self.task['lighthouse_log']. This change causes those characters to be ignored/thrown away so the lines can be properly represented in ascii. For Python3 support, any unicode() methods will need to be updated to use encode() and decode() methods.