### PR TITLE
Update ZEIT to Vercel

### DIFF
--- a/internal/optimization_checks.py
+++ b/internal/optimization_checks.py
@@ -221,7 +221,8 @@ class OptimizationChecks(object):
                       '.yimg.',
                       '.yahooapis.com'],
             'Yottaa': ['.yottaa.net'],
-            'ZEIT Smart CDN': ['.zeit.co'],
+            'Vercel': ['.vercel.com',
+                       '.zeit.co'],
             'Zenedge': ['.zenedge.net']
         }
         self.cdn_headers = {
@@ -291,7 +292,8 @@ class OptimizationChecks(object):
             'XLabs Security': [{'x-cdn': 'XLabs Security'}],
             'Yunjiasu': [{'Server': 'yunjiasu'}],
             'Zenedge': [{'X-Cdn': 'Zenedge'}],
-            'ZEIT Smart CDN': [{'Server': 'now'}],
+            'Vercel': [{'Server': 'Vercel'},
+                       {'Server': 'now'}],
             'Zycada Networks': [{'X-Zy-Server': ''}]
         }
         # spell-checker: enable


### PR DESCRIPTION
https://zeit.co has been renamed to https://vercel.com