### PR TITLE
Add CI & test for Ubuntu installation script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
+dist: bionic
 sudo: required
 language: php
-services:
-  - docker
-script:
-  - docker build --tag wptagent .
-after_script:
-  - docker images
+
+jobs:
+  include:
+    - name: Build Docker image
+      services:
+        - docker
+      script:
+        - docker build --tag wptagent .
+      after_script:
+        - docker images
+
+    - name: Ubuntu installation test
+      script:
+        - ./ubuntu_install.sh
+        - ./test/ubuntu_install.sh

--- a/test/ubuntu_install.sh
+++ b/test/ubuntu_install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Test script for ubuntu_install.sh
+
+set -eux
+
+# Check if packages are installed
+dpkg --status python2.7 > /dev/null
+dpkg --status python-pip > /dev/null
+dpkg --status imagemagick > /dev/null
+dpkg --status ffmpeg > /dev/null
+dpkg --status xvfb > /dev/null
+dpkg --status python2.7 > /dev/null
+dpkg --status dbus-x11 > /dev/null
+dpkg --status cgroup-tools > /dev/null
+dpkg --status traceroute > /dev/null
+dpkg --status software-properties-common > /dev/null
+dpkg --status psmisc > /dev/null
+dpkg --status libnss3-tools > /dev/null
+dpkg --status iproute2 > /dev/null
+dpkg --status net-tools > /dev/null
+dpkg --status git > /dev/null
+dpkg --status curl > /dev/null
+dpkg --status nodejs > /dev/null
+dpkg --status google-chrome-stable > /dev/null
+dpkg --status google-chrome-beta > /dev/null
+dpkg --status google-chrome-unstable > /dev/null
+dpkg --status firefox > /dev/null
+dpkg --status firefox-trunk > /dev/null
+dpkg --status firefox-esr > /dev/null
+dpkg --status ttf-mscorefonts-installer > /dev/null
+dpkg --status fonts-noto > /dev/null
+dpkg --status fonts-noto-cjk > /dev/null
+dpkg --status fonts-noto-cjk-extra > /dev/null
+dpkg --status fonts-noto-color-emoji > /dev/null
+dpkg --status fonts-noto-hinted > /dev/null
+dpkg --status fonts-noto-mono > /dev/null
+dpkg --status fonts-noto-unhinted > /dev/null
+
+# TODO Following is commented out temporary.
+# The max number of open file is currently configured in /etc/security/limits.conf,
+# but it is ignored on systemd-based systems.
+
+# # Soft limit of max number of open files
+# test "$(ulimit -Sn)" == "250000"
+# # Hard limit of max number of open files
+# test "$(ulimit -Hn)" == "300000"
+
+sudo sysctl --system
+test "$(sysctl net.ipv4.tcp_syn_retries)" == "net.ipv4.tcp_syn_retries = 4"

--- a/ubuntu_install.sh
+++ b/ubuntu_install.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -eu
+
 until sudo apt-get update
 do
     sleep 1
@@ -8,7 +11,7 @@ do
     sleep 1
 done
 # Unavailable on Ubuntu 18.04 but needed on earlier releases
-sudo apt-get install -y python-software-properties
+sudo apt-get install -y python-software-properties || :
 sudo dbus-uuidgen --ensure
 until sudo pip install dnspython monotonic pillow psutil requests git+git://github.com/marshallpierce/ultrajson.git@v1.35-gentoo-fixes tornado wsaccel xvfbwrapper brotli marionette_driver future
 do


### PR DESCRIPTION
This PR adds CI and test script for the Ubuntu installation script (ubuntu_install.sh).

NOTE:
By running the test script, I found the max number of open files may not be configured properly because /etc/security/limits.conf is ignored on systemd-based systems.
I tried to fix that, but I could not find a way to fix it unless creating a systemd service of wptagent and set `LimitNOFILE` value in the service file.
I'm not sure if I should create the systemd service, so [I commented out the lines to test the max number of open files](https://github.com/phanect/wptagent/blob/test-ubuntu-install/.github/workflows/test_ubuntu_install.sh#L41) for now.