### PR TITLE
Ignore visually hidden elements when finding heroes.

### DIFF
--- a/internal/js/hero_elements.js
+++ b/internal/js/hero_elements.js
@@ -113,7 +113,7 @@ function isLargestHero(name, area) {
 }
 
 function isVisibleElement(rect) {
-  return rect.height > 0;
+  return rect.width * rect.height > 1;
 }
 
 function isInViewport(rect) {


### PR DESCRIPTION
Kind of an edge case, but I wanted to fix it anyway.

A common technique to visually hide elements is to set their width and height to 1px each. These elements are normally intended for screen readers only and should not be considered hero elements, which are based on visual analysis.

This change just ensures that a hero element has a total area at least 2px.