### PR TITLE
New param `shaperLimit` to runtest.php for network shaping

### DIFF
--- a/internal/traffic_shaping.py
+++ b/internal/traffic_shaping.py
@@ -73,7 +73,7 @@ class TrafficShaper(object):
             ret = self.shaper.reset()
         return ret
 
-    def _to_int(s):
+    def _to_int(self, s):
         return int(re.search(r'\d+', str(s)).group())
 
     def configure(self, job, task):


### PR DESCRIPTION
`tc qdisc` can take `limit` parameter for the buffer size of the queue but there's no parameter to set it. If I understand correctly, no "correct" value for `limit` can be calculated so it should be configured by test designers. 

The `limit` param is described in [`netem(8)` manpage](https://www.man7.org/linux/man-pages/man8/tc-netem.8.html):

>  limit packets
>       maximum number of packets the qdisc may hold queued at a time.

---

I'll test this patch on our private instance, and at the same time, I have made this pull-req here to discuss this feature.

## refs

* https://github.com/WPO-Foundation/webpagetest/pull/1367