### PR TITLE
Ignore unsupported character sequences when storing font checks

### DIFF
--- a/internal/optimization_checks.py
+++ b/internal/optimization_checks.py
@@ -1025,8 +1025,8 @@ class OptimizationChecks(object):
                                 entry = reader.tables[tag]
                                 if tables is None:
                                     tables = {}
-                                tables[tag] = entry.length
-                            ttf.close()                            
+                                tables[tag.decode('utf-8', 'ignore')] = entry.length
+                            ttf.close()
                             if tables is not None:
                                 self.font_results[request_id] = {'table_sizes': tables}
                 except Exception:


### PR DESCRIPTION
I'm not sure if this is the right way to fix this. When I run a test against https://www-mw.jjill.com/, the agent crashes during the optimization checks with this stack trace:

```
OverflowError: Unterminated UTF-8 sequence when encoding string
Traceback (most recent call last):
  File "/wptagent/wptagent.py", line 193, in run_single_test
    browser.run_task(self.task)
  File "/wptagent/internal/chrome_desktop.py", line 156, in run_task
    DevtoolsBrowser.run_task(self, task)
  File "/wptagent/internal/devtools_browser.py", line 234, in run_task
    self.on_start_processing(task)
  File "/wptagent/internal/chrome_desktop.py", line 228, in on_start_processing
    DevtoolsBrowser.on_start_processing(self, task)
  File "/wptagent/internal/devtools_browser.py", line 256, in on_start_processing
    optimization.join()
  File "/wptagent/internal/optimization_checks.py", line 402, in join
    gz_file.write(json.dumps(self.results))
```

I'm guessing the root cause is a borked font, because it has table keys like:

```
$hm
0CF
ap
ea
}�
�
�k
```