### PR TITLE
fixed for windows 7 which without EventContextId

### DIFF
--- a/internal/microsoft_edge.py
+++ b/internal/microsoft_edge.py
@@ -397,8 +397,8 @@ class Edge(DesktopBrowser):
                     message['data']['URL'].startswith('http') and \
                     message['data']['URL'].startswith('http') and \
                     not message['data']['URL'].startswith('http://127.0.0.1:8888'):
-                if 'EventContextId' in message['data']:
-                    self.pageContexts.append(message['data']['EventContextId'])
+                tid = message['data']['EventContextId']  if 'EventContextId' in message['data'] else  message['tid']
+                self.pageContexts.append(tid)
                 self.CMarkup.append(message['data']['CMarkup'])
                 self.navigating = False
                 self.last_activity = monotonic()
@@ -416,8 +416,8 @@ class Edge(DesktopBrowser):
                     message['data']['Markup'] in self.CMarkup:
                 logging.debug("Injecting script: \n%s", self.job['injectScript'])
                 self.execute_js(self.job['injectScript'])
-            if 'EventContextId' in message['data'] and \
-                    message['data']['EventContextId'] in self.pageContexts:
+            tid = message['data']['EventContextId']  if 'EventContextId' in message['data'] else  message['tid'];
+            if  tid in self.pageContexts:
                 if message['Event'] == 'Mshtml_WebOCEvents_DocumentComplete':
                     if 'CMarkup' in message['data'] and message['data']['CMarkup'] in self.CMarkup:
                         if 'loadEventStart' not in self.page:


### PR DESCRIPTION
use tid on if without EventContextId
```
tid = message['data']['EventContextId']  if 'EventContextId' in message['data'] else  message['tid']
```
non-english as system language should patch by: https://github.com/WPO-Foundation/wpt-etw/pull/10
for now, download [wpt-etw](https://github.com/qxo/wpt-etw/suites/928526904/artifacts/11400781)
unzip and replace wpt-etw.exe should be work :)