### PR TITLE
Disable cgroups throttling on Lighthouse runs when lighthouseConfig is provided

### DIFF
--- a/internal/desktop_browser.py
+++ b/internal/desktop_browser.py
@@ -282,7 +282,9 @@ class DesktopBrowser(BaseBrowser):
 
     def launch_browser(self, command_line):
         """Launch the browser and keep track of the process"""
-        command_line = self.enable_cpu_throttling(command_line)
+        if not self.job['lighthouse_config'] or not self.task['running_lighthouse']:
+            # Only enable CPU throttling for Lighthouse runs if a custom config was not provided
+            command_line = self.enable_cpu_throttling(command_line)
         logging.debug(command_line)
         if platform.system() == 'Windows':
             self.proc = subprocess.Popen(command_line, shell=True)


### PR DESCRIPTION
When I submitted #352 I accidentally enabled double CPU throttling for Lighthouse runs when a) cgroups throttling is enabled and b) the lighthouseConfig option is used. My test agents all run in Docker containers so I never actually tested how the lighthouseConfig worked on an agent that runs with the `--throttle` flag. The cgroups throttling is still applied and then Lighthouse applies its own DevTools throttling on top of that.

I don't know if this patch is the "right" approach - I wasn't sure whether `WPTAgent` should be concerned with job parameters like `lighthouseConfig`. I guess the alternative would be to put this logic in `DesktopBrowser.enable_cpu_throttling()` and have it set `throttling_cpu = False`. LMK what you think.

Edit: Also keen to know your thoughts on comments in source code. This block of code is a bit like "huh? what?" and could probably do with a comment explaining the logic, but I didn't want to pollute your codebase with comments.