### PR TITLE
Roughing in additional metadata collections for fonts

### DIFF
--- a/internal/font_metadata.py
+++ b/internal/font_metadata.py
@@ -15,6 +15,14 @@ _NAME_ID_LICENSE_URL = 14
 _MAX_NAME_LEN = 64
 
 
+def _safe_result_type(v):
+    return type(v) in {bool, int, float, complex, str}
+
+
+def _safe_map(m):
+    return {k: v for k, v in m.items() if _safe_result_type(v)}
+
+
 def _read_names(ttf, name_ids):
     names = {}
     try:
@@ -37,11 +45,9 @@ def _read_names(ttf, name_ids):
 
 def _read_os2(ttf):
     try:
-        os2 = ttf['OS/2']
-        return {
-            'usWeightClass': os2.usWeightClass,
-            'usWidthClass': os2.usWidthClass,
-        }
+        os2 = _safe_map(ttf['OS/2'].__dict__)
+        os2['panose'] = _safe_map(ttf['OS/2'].panose.__dict__)
+        return os2
     except Exception:
         logging.exception('Error reading font names')
     return None

--- a/internal/font_metadata.py
+++ b/internal/font_metadata.py
@@ -1,0 +1,120 @@
+# Copyright 2020 WebPageTest LLC.
+# Copyright 2020 Google Inc.
+# Use of this source code is governed by the Apache 2.0 license that can be
+# found in the LICENSE file.
+"""Extract metadata from OpenType fonts."""
+
+from fontTools.ttLib import TTFont
+import functools
+import logging
+
+
+_NAME_ID_VERSION = 5
+_NAME_ID_POSTSCRIPT_NAME = 6
+_NAME_ID_LICENSE_URL = 14
+_MAX_NAME_LEN = 64
+
+
+def _read_names(ttf, name_ids):
+    names = {}
+    try:
+        for name in ttf['name'].names:
+            if not name.nameID in name_ids:
+                continue
+            if not name.isUnicode():
+                continue
+            try:
+                names[name.nameID] = name.toUnicode()[:_MAX_NAME_LEN]
+            except Exception:
+                logging.exception('Error converting name to unicode')
+
+    except Exception:
+        logging.exception('Error reading font names')
+    if not names:
+        return None
+    return names
+
+
+def _read_os2(ttf):
+    try:
+        os2 = ttf['OS/2']
+        return {
+            'usWeightClass': os2.usWeightClass,
+            'usWidthClass': os2.usWidthClass,
+        }
+    except Exception:
+        logging.exception('Error reading font names')
+    return None
+
+
+def _read_fvar(ttf):
+    if 'fvar' in ttf:
+        try:
+            return {
+                a.axisTag: {
+                    'min': a.minValue,
+                    'default': a.defaultValue,
+                    'max': a.maxValue
+                }
+                for a in ttf['fvar'].axes
+            }
+        except Exception:
+            logging.exception('Error reading axes')
+    return None
+
+
+def _read_codepoint_glyph_counts(ttf):
+    try:
+        glyph_count = len(ttf.getGlyphOrder())
+        unicode_cmaps = (t.cmap.keys() for t in ttf['cmap'].tables if t.isUnicode())
+        unique_codepoints = functools.reduce(lambda acc, u: acc | u, unicode_cmaps, set())
+        return {
+            'num_cmap_codepoints': len(unique_codepoints),
+            'num_glyphs': glyph_count
+        }
+    except Exception:
+        logging.exception('Error reading codepoint and glyph count')
+    return None
+
+
+def read_metadata(font):
+    ttf = TTFont(font, lazy=True)
+    try:
+        ttf.getGlyphNames()
+    except Exception:
+        logging.error('Not a vaild font: ' + request['url'])
+        return None
+    reader = ttf.reader
+
+    table_sizes = {tag: reader.tables[tag].length 
+                   for tag in sorted(reader.keys())}
+    names = _read_names(ttf, (_NAME_ID_VERSION,
+        _NAME_ID_POSTSCRIPT_NAME, _NAME_ID_LICENSE_URL))
+    os2_info = _read_os2(ttf)
+    axes = _read_fvar(ttf)
+    counts = _read_codepoint_glyph_counts(ttf)
+
+    ttf.close()
+
+    metadata = {'table_sizes': table_sizes}
+    if names:
+        metadata['names'] = names
+    if os2_info:
+        metadata['os2_info'] = os2_info
+    if axes:
+        metadata['axes'] = axes
+    if counts:
+        metadata['counts'] = counts
+
+    return metadata
+
+
+def main():
+    import pprint
+    import sys
+    for filename in sys.argv[1:]:
+        pp = pprint.PrettyPrinter()
+        pp.pprint(read_metadata(filename))
+
+if __name__ == "__main__":
+    main()

--- a/internal/optimization_checks.py
+++ b/internal/optimization_checks.py
@@ -1023,7 +1023,7 @@ class OptimizationChecks(object):
                         if sniff_type is not None and sniff_type in ['OTF', 'TTF', 'WOFF', 'WOFF2']:
                             font_info = font_metadata.read_metadata(request['body'])
                             if font_info is not None:
-                                self.font_results[request_id] = {'table_sizes': tables}
+                                self.font_results[request_id] = font_info
                 except Exception:
                     logging.exception('Error checking font')
         except Exception:

--- a/internal/optimization_checks.py
+++ b/internal/optimization_checks.py
@@ -1014,34 +1014,20 @@ class OptimizationChecks(object):
         """Check each request to extract metadata about fonts"""
         start = monotonic()
         try:
-            from fontTools.ttLib import TTFont
+            import font_metadata
             for request_id in self.requests:
                 try:
                     request = self.requests[request_id]
                     if 'body' in request:
                         sniff_type = self.sniff_file_content(request['body'])
                         if sniff_type is not None and sniff_type in ['OTF', 'TTF', 'WOFF', 'WOFF2']:
-                            tables = None
-                            ttf = TTFont(request['body'], lazy=True)
-                            try:
-                                ttf.getGlyphNames()
-                            except Exception:
-                                logging.error('Not a vaild font: ' + request['url'])
-                                continue
-                            reader = ttf.reader
-                            tags = sorted(reader.keys())
-                            for tag in tags:
-                                entry = reader.tables[tag]
-                                if tables is None:
-                                    tables = {}
-                                tables[tag] = entry.length
-                            ttf.close()                            
-                            if tables is not None:
+                            font_info = font_metadata.read_metadata(request['body'])
+                            if font_info is not None:
                                 self.font_results[request_id] = {'table_sizes': tables}
                 except Exception:
                     logging.exception('Error checking font')
         except Exception:
-            pass
+            logging.exception('Error checking fonts')
         self.font_time = monotonic() - start
 
     def get_header_value(self, headers, name):


### PR DESCRIPTION
Collection additional metadata about fonts to help with 2020 almanac. Sample output (pprint'd for legibility):

```
Lobster (static)
{'counts': {'num_cmap_codepoints': 94, 'num_glyphs': 98},
 'names': {5: 'Version 2.100',
           6: 'Lobster-Regular',
           14: 'http://scripts.sil.org/OFL'},
 'os2_info': {'usWeightClass': 400, 'usWidthClass': 5},
 'table_sizes': {'GPOS': 132,
                 'GSUB': 48,
                 'OS/2': 96,
                 'cmap': 256,
                 'gasp': 8,
                 'glyf': 13876,
                 'head': 54,
                 'hhea': 36,
                 'hmtx': 372,
                 'loca': 0,
                 'maxp': 32,
                 'name': 572,
                 'post': 974}}

Raleway (variable)
{'axes': {'wght': {'default': 100.0, 'max': 900.0, 'min': 100.0}},
 'counts': {'num_cmap_codepoints': 224, 'num_glyphs': 264},
 'names': {5: 'Version 4.026',
           6: 'Raleway-Thin',
           14: 'http://scripts.sil.org/OFL'},
 'os2_info': {'usWeightClass': 100, 'usWidthClass': 5},
 'table_sizes': {'GDEF': 1718,
                 'GPOS': 28140,
                 'GSUB': 658,
                 'HVAR': 991,
                 'OS/2': 96,
                 'STAT': 184,
                 'avar': 50,
                 'cmap': 648,
                 'fvar': 126,
                 'gasp': 8,
                 'glyf': 13885,
                 'gvar': 29378,
                 'head': 54,
                 'hhea': 36,
                 'hmtx': 1056,
                 'loca': 0,
                 'maxp': 32,
                 'name': 1226,
                 'post': 1043}}
```

Creating a draft because I want to sanity check this seems potentially acceptable.