### PR TITLE
Add message server handler for /wpt-start-recording and fix CORS errors

### DIFF
--- a/internal/message_server.py
+++ b/internal/message_server.py
@@ -76,11 +76,14 @@ class TornadoRequestHandler(tornado.web.RequestHandler):
                 response += cgi.escape(json.dumps(MESSAGE_SERVER.config))
                 response += '</div>'
             response += "</body></html>"
+        elif self.request.uri == '/wpt-start-recording':
+            response = 'ok'
 
         if response is not None:
             self.set_status(200)
             self.set_header("Content-Type", content_type)
             self.set_header("Referrer-Policy", "no-referrer")
+            self.set_header("Access-Control-Allow-Origin", "*")
             self.write(response)
 
     def post(self):


### PR DESCRIPTION
The fetch() call for the wpt-start-recording marker throws a CORS error. This error ends up being captured by some JS error reporting tools like Sentry.

There's probably a much more elegant solution, but I figure setting Access-Control-Allow-Origin on every response couldn't do any harm..? (:grimacing:)

![Screenshot_2020-08-04 TypeError Failed to fetch](https://user-images.githubusercontent.com/794263/89258849-1a605b80-d67d-11ea-849b-3ed5ecc50fce.png)
