### PR TITLE
Add Brave to the README; fix typo: s/lies/lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ run the agent in a docker container.
     * if/else/endif
 
 ## Contributing
-There are 2 separate lies of development under different licenses and pull requests are accepted to either of them.  The master branch where most active development is occurring is under the [Polyform Shield 1.0.0 license](LICENSE.md) and there is an "apache" branch which is under the more permissive Apache 2.0 license.
+There are 2 separate lines of development under different licenses and pull requests are accepted to either of them.  The master branch where most active development is occurring is under the [Polyform Shield 1.0.0 license](LICENSE.md) and there is an "apache" branch which is under the more permissive Apache 2.0 license.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Chrome is the only browser that currently supports manipulating requests (changi
 * Chrome (Stable, Beta and Unstable)
 * Firefox (Stable and Nightly)
 * Opera (Stable, Beta and Developer)
+* Brave (Stable)
 
 ### Windows
 * Chrome (Stable, Beta, Dev and Canary)


### PR DESCRIPTION
Adds Brave (Stable) to the README for Linux, and fixes a typo