### PR TITLE
Fall back to 0 when Nav Timing Level 2 is Unavailable

### DIFF
--- a/internal/js/page_data.js
+++ b/internal/js/page_data.js
@@ -39,7 +39,7 @@ pageData["firstPaint"] = 0;
 // Try the standardized paint timing api
 try {
   var entries = performance.getEntriesByType('paint');
-  var navStart = performance.getEntriesByType("navigation")[0].startTime;
+  var navStart = performance.getEntriesByType("navigation").length > 0 ?  performance.getEntriesByType("navigation")[0].startTime : 0;
   for (var i = 0; i < entries.length; i++) {
     var entryTime = entries[i].startTime - navStart;
     pageData["PerformancePaintTiming." + entries[i]['name']] = entryTime;


### PR DESCRIPTION
Safari has an open bug for Navigation Timing Level 2: https://bugs.webkit.org/show_bug.cgi?id=184363

We currently check for the `startTime` value in the agent code when looking at Paint Timings. This PR falls back to 0 if `performance.getEntriesByType("navigation")` is empty.

This should address https://github.com/WPO-Foundation/webpagetest/issues/1490