### PR TITLE
Added Parspack CDN to the CDN list

### DIFF
--- a/internal/optimization_checks.py
+++ b/internal/optimization_checks.py
@@ -195,6 +195,7 @@ class OptimizationChecks(object):
             'Optimal CDN': ['.optimalcdn.com'],
             'PageCDN': ['pagecdn.io'],
             'PageRain': ['.pagerain.net'],
+            'Parspack CDN': ['.parspack.net'],
             'Pressable CDN': ['.pressablecdn.com'],
             'PUSHR': ['.pushrcdn.com'],
             'Rackspace': ['.raxcdn.com'],


### PR DESCRIPTION
Parspack is an Iranian CDN provider.