### PR TITLE
lighthouse for current browser session

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -744,6 +744,7 @@ class DevtoolsBrowser(object):
         proc.communicate()
 
     def run_lighthouse_test(self, task):
+        self.task = task
         if self.must_exit_now:
             return
         self.profile_start('dtbrowser.run_lighthouse_test')


### PR DESCRIPTION
Hi @pmeenan,

In my org, we need to test against pages behind authentication (which was identified with a cookie with max-age=session). With these changes, WPT is now able to do that (tested on Windows+Ubuntu 18.04).

Pls help to take a look whether this is something WPT wants to take in.

This might also address the issue https://github.com/WPO-Foundation/wptagent/issues/395 