### PR TITLE
Map netlog priorities to the Dev Tools equivalents

### DIFF
--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -51,6 +51,13 @@ class DevToolsParser(object):
         self.result = {'pageData': {}, 'requests': []}
         self.request_ids = {}
         self.script_ids = {}
+        self.PRIORITY_MAP = {
+            "HIGHEST": "Highest",
+            "MEDIUM": "High",
+            "LOW": "Medium",
+            "LOWEST": "Low",
+            "IDLE": "Lowest"
+        }
 
     def process(self):
         """Main entry point for processing"""
@@ -647,9 +654,13 @@ class DevToolsParser(object):
                                 request['initiator'] = self.script_ids[frame['scriptId']]
                                 break
                 if 'initialPriority' in raw_request:
+                    if raw_request['initialPriority'] in self.PRIORITY_MAP:
+                        raw_request['initialPriority'] = self.PRIORITY_MAP[raw_request['initialPriority']]
                     request['priority'] = raw_request['initialPriority']
                     request['initial_priority'] = raw_request['initialPriority']
                 elif 'metrics' in raw_request and 'priority' in raw_request['metrics']:
+                    if raw_request['metrics']['priority'] in self.PRIORITY_MAP:
+                        raw_request['metrics']['priority'] = self.PRIORITY_MAP[raw_request['metrics']['priority']]
                     request['priority'] = raw_request['metrics']['priority']
                 request['server_rtt'] = None
                 request['headers'] = {'request': [], 'response': []}
@@ -890,6 +901,8 @@ class DevToolsParser(object):
                                             request[mapping[key]] = str(entry[key])
                                 except Exception:
                                     logging.exception('Error copying request key %s', key)
+                            if 'priority' in request and request['priority'] in self.PRIORITY_MAP:
+                                request['priority'] = self.PRIORITY_MAP[request['priority']]
                             if protocol is not None:
                                 request['protocol'] = protocol
                             if 'start' in entry:

--- a/internal/support/trace_parser.py
+++ b/internal/support/trace_parser.py
@@ -60,6 +60,13 @@ class Trace():
         self.netlog_event_types = {}
         self.v8stats = None
         self.v8stack = {}
+        self.PRIORITY_MAP = {
+            "HIGHEST": "Highest",
+            "MEDIUM": "High",
+            "LOW": "Medium",
+            "LOWEST": "Low",
+            "IDLE": "Lowest"
+        }
         return
 
     ##########################################################################
@@ -511,6 +518,8 @@ class Trace():
             if trace_event['name'] == 'ResourceSendRequest':
                 if 'priority' in trace_event['args']['data']:
                     request['priority'] = trace_event['args']['data']['priority']
+                    if request['priority'] in self.PRIORITY_MAP:
+                        request['priority'] = self.PRIORITY_MAP[request['priority']]
                 if 'frame' in trace_event['args']['data']:
                     request['frame'] = trace_event['args']['data']['frame']
                 if 'renderBlocking' in trace_event['args']['data']:
@@ -1052,6 +1061,8 @@ class Trace():
                                         request['priority'] = 'LOWEST'
                                     else:
                                         request['priority'] = 'IDLE'
+                                    if request['priority'] in self.PRIORITY_MAP:
+                                        request['priority'] = self.PRIORITY_MAP[request['priority']]
                             if 'first_byte' not in request and 'first_byte' in stream:
                                 request['first_byte'] = stream['first_byte']
                             if 'end' not in request and 'end' in stream:
@@ -1584,6 +1595,8 @@ class Trace():
         entry = self.netlog['url_request'][request_id]
         name = trace_event['name']
         if 'priority' in params:
+            if params['priority'] in self.PRIORITY_MAP:
+                params['priority'] = self.PRIORITY_MAP[params['priority']]
             entry['priority'] = params['priority']
             if 'initial_priority' not in entry:
                 entry['initial_priority'] = params['priority']


### PR DESCRIPTION
This changes the reported Priorities to use the same names as Dev Tools uses for the different priority levels.  I am in the process of moving Blink to also use the dev tools names so hopefully we can have one set of priority names that we use when talking about Chrome prioritization (netlog internally will still use the net names because it is locked into the API but I will change the [priorities doc](https://docs.google.com/document/d/1bCDuq9H1ih9iNjgzyAL0gpwNFiEP4TZS-YLRp_RuMlc/edit?usp=sharing) to de-emphasize the net names).

With this, both Dev Tools and WPT will show the same names for priorities which should make it a lot easier to talk about, particularly as Priority Hints are going to be coming along soon.

I'll have a PR shortly to also map the names in the UI for older tests so they are displayed consistently.