### PR TITLE
Fix #435 by adding a break 

### DIFF
--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -1081,6 +1081,7 @@ class Firefox(DesktopBrowser):
                             and 'start' in req and request['full_url'] == req['url']:
                         req['claimed'] = True
                         self.populate_request(request, req)
+                        break
                 except Exception:
                     logging.exception('Error populating request')
         # Add any events from the logs that weren't reported by the extension


### PR DESCRIPTION
Looks like issue #435 was caused by an over eager set of for loops that simply needed a `break` when a match occurred so that the same request couldn't be matched to multiple requests in the logs.