### PR TITLE
Firefox now looks for disableAVIF, disableWEBP and disableJXL params

### DIFF
--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -114,7 +114,6 @@ class Firefox(DesktopBrowser):
             except Exception:
                 pass
 
-
         # Prepare the config for the extension to query
         if self.job['message_server'] is not None:
             config = None


### PR DESCRIPTION
This closes issue #440 and helps us with https://github.com/WPO-Foundation/webpagetest/issues/1558