### PR TITLE
Add Tencent Cloud CDN services to CDN listing

### DIFF
--- a/internal/optimization_checks.py
+++ b/internal/optimization_checks.py
@@ -292,6 +292,8 @@ class OptimizationChecks(object):
                        'tbcdn.cn',
                        '.taobaocdn.com'],
             'Telenor': ['.cdntel.net'],
+            'Tencent': ['.cdn.dnsv1.com',
+                        '.dsa.dnsv1.com'],
             'TRBCDN': ['.trbcdn.net'],
             'Twitter': ['.twimg.com'],
             'UnicornCDN': ['.unicorncdn.net'],


### PR DESCRIPTION
Tencent is a major Chinese Cloud Provider. The offered CDN services are currently not detected by WPT.

The CNAMEs are documented here:
* [Content Delivery Network](https://intl.cloud.tencent.com/document/product/228/3121)
* [Enterprise Content Delivery Network](https://intl.cloud.tencent.com/document/product/570/11134)