### PR TITLE
Disable lighthouse full page screenshots

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -797,7 +797,7 @@ class DevtoolsBrowser(object):
             if self.job['keep_lighthouse_trace']:
                 command.append('--save-assets')
             if not self.job['keep_lighthouse_screenshots']:
-                command.extend(['--skip-audits', 'screenshot-thumbnails,final-screenshot'])
+                command.extend(['--skip-audits', 'screenshot-thumbnails,final-screenshot,full-page-screenshot'])
             form_factor_command = '--form-factor'
             if self.options.android:
                 command.extend([form_factor_command, 'mobile'])


### PR DESCRIPTION
Apparently a new audit was added in lighthouse 8.4 that adds more screenshots to the lighthouse raw data (WPT disables the others).  This disables the new full-page-screenshot audit, removing the binary data from the lighthouse json.

Fixes https://github.com/HTTPArchive/httparchive.org/issues/476