### PR TITLE
feat(wappalyzer): Add option to disable Wappalyzer

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -298,7 +298,8 @@ class DevtoolsBrowser(object):
             # Run the video post-processing
             if self.use_devtools_video and self.job['video']:
                 self.process_video()
-            self.wappalyzer_detect(task, self.devtools.main_request_headers)
+            if self.job.get('wappalyzer'):
+                self.wappalyzer_detect(task, self.devtools.main_request_headers)
             # wait for the background optimization checks
             optimization.join()
 

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -516,6 +516,8 @@ class WebPageTest(object):
                     job['fps'] = self.fps
                 if 'warmup' not in job:
                     job['warmup'] = 0
+                if 'wappalyzer' not in job:
+                    job['wappalyzer'] = 1
                 if job['type'] == 'lighthouse':
                     job['fvonly'] = 1
                     job['lighthouse'] = 1


### PR DESCRIPTION
This adds an option (`wappalyzer`) that can be passed with a value of `0` to disable Wappalyzer detection on a given run.

It defaults to `1` to ensure that we align with what WebPageTest has defaulted to up to this point, and don't break things for folks.

Closes #449 