### PR TITLE
Added support for waitFor script command

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -713,6 +713,18 @@ class DevtoolsBrowser(object):
             self.devtools.type_text(command['target'])
         elif command['command'] == 'keypress':
             self.devtools.keypress(command['target'])
+        elif command['command'] == 'waitfor':
+            try:
+                self.devtools.wait_for_script = command['target'] if command['target'] else None
+            except Exception:
+                logging.exception('Error processing waitfor command')
+        elif command['command'] == 'waitinterval':
+            try:
+                interval = float(command['target'])
+                if interval > 0:
+                    self.devtools.wait_interval = interval
+            except Exception:
+                logging.exception('Error processing waitfor command')
 
     def navigate(self, url):
         """Navigate to the given URL"""


### PR DESCRIPTION
This will allow for arbitrary end-of-step logic for SPA's where the supplied JavaScript is polled every 5 seconds (configurable with waitInterval command) until it returns true.

For example, this will run the speedometer benchmark and wait for it to complete before stopping:

```javascript
logData	0
navigate	https://browserbench.org/Speedometer2.0/
logData	1
setTimeout	600
waitFor	document.getElementById('results-with-statistics') && document.getElementById('results-with-statistics').innerText.length > 0
execAndWait	startTest();
```

Documentation PR coming separately.

For https://github.com/WPO-Foundation/webpagetest/issues/1657