### PR TITLE
Add support for locally-defined custom metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /visible.sh
 /update.sh
 /work
+/custom
 /*.cmd
 /alive.txt
 /10fps.sh

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -6,6 +6,7 @@
 """Main entry point for interfacing with WebPageTest server"""
 import base64
 from datetime import datetime
+import glob
 import gzip
 import hashlib
 import logging
@@ -218,7 +219,25 @@ class WebPageTest(object):
         if os.path.isfile(margins_file):
             with open(margins_file, 'r') as f_in:
                 self.margins = json.load(f_in)
+        # Load any locally-defined custom metrics from {agent root}/custom/metrics/*.js
+        self.custom_metrics = {}
+        self.load_local_custom_metrics()
     # pylint: enable=E0611
+
+    def load_local_custom_metrics(self):
+        metrics_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'custom', 'metrics')
+        if (os.path.isdir(metrics_dir)):
+            files = glob.glob(metrics_dir + '/*.js')
+            for file in files:
+                try:
+                    with open(file, 'rt') as f:
+                        metric_value = f.read()
+                        if metric_value:
+                            metric_name = os.path.basename(file)[:-3]
+                            self.custom_metrics[metric_name] = metric_value
+                            logging.debug('Loaded custom metric %s from %s', metric_name, file)
+                except Exception:
+                    pass
 
     def benchmark_cpu(self):
         """Benchmark the CPU for mobile emulation"""
@@ -581,6 +600,13 @@ class WebPageTest(object):
                 # Add the non-serializable members
                 if self.health_check_server is not None:
                     job['health_check_server'] = self.health_check_server
+                # add any locally-defined custom metrics (server versions override locals with the same name)
+                if self.custom_metrics:
+                    if 'customMetrics' not in job:
+                        job['customMetrics'] = {}
+                    for name in self.custom_metrics:
+                        if name not in job['customMetrics']:
+                            job['customMetrics'][name] = self.custom_metrics[name]
             except Exception:
                 logging.exception("Error processing job json")
         self.job = job


### PR DESCRIPTION
This allows for the agents to be configured with custom metrics in {agentdir}/custom/metrics/*.js in addition to any supplied by the server.

For installations with lots of custom metrics, this can be WAY more efficient than storing the custom metric with the test job (and raw test) for every test.  For example, the HTTP Archive uses [~100k of custom metrics](https://github.com/HTTPArchive/custom-metrics) to extract things for the web almanac.

The agents can be configured to pull from the custom metrics repo at the same time that they update the agent code (hourly).