### PR TITLE
Add Chrome's optimization guide service to the blocklist

### DIFF
--- a/internal/chrome_android.py
+++ b/internal/chrome_android.py
@@ -49,7 +49,8 @@ HOST_RULES = [
     '"MAP clients1.google.com 127.0.0.1"',
     '"MAP update.googleapis.com 127.0.0.1"',
     '"MAP redirector.gvt1.com 127.0.0.1"',
-    '"MAP offlinepages-pa.googleapis.com 127.0.0.1"'
+    '"MAP offlinepages-pa.googleapis.com 127.0.0.1"',
+    '"MAP optimizationguide-pa.googleapis.com 127.0.0.1"'
 ]
 
 DISABLE_CHROME_FEATURES = [

--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -46,7 +46,8 @@ HOST_RULES = [
     '"MAP redirector.gvt1.com 127.0.0.1"',
     '"MAP laptop-updates.brave.com 127.0.0.1"',
     '"MAP offlinepages-pa.googleapis.com 127.0.0.1"',
-    '"MAP edge.microsoft.com 127.0.0.1"'
+    '"MAP edge.microsoft.com 127.0.0.1"',
+    '"MAP optimizationguide-pa.googleapis.com 127.0.0.1"'
 ]
 
 ENABLE_CHROME_FEATURES = [


### PR DESCRIPTION
Looks like Chrome started leaking more requests: https://www.webpagetest.org/result/220214_BiDc6B_ETQ/1/details/#waterfall_view_step1

The command-line flag to turn it off doesn't appear to be completely successful.