### PR TITLE
Use trace events to surface unused and mismatched preloads...

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -377,6 +377,7 @@ class DevTools(object):
                         "cc",
                         "gpu",
                         "blink.net",
+                        "blink.resource",
                         "disabled-by-default-v8.runtime_stats"
                     ]
             else:
@@ -424,6 +425,8 @@ class DevTools(object):
                 trace_config["includedCategories"].append("blink.user_timing")
             if "netlog" not in trace_config["includedCategories"]:
                 trace_config["includedCategories"].append("netlog")
+            if "blink.resource" not in trace_config["includedCategories"]:
+                trace_config["includedCategories"].append("blink.resource")
             if "disabled-by-default-netlog" not in trace_config["includedCategories"]:
                 trace_config["includedCategories"].append("disabled-by-default-netlog")
             if "disabled-by-default-blink.feature_usage" not in trace_config["includedCategories"]:

--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -1117,6 +1117,10 @@ class DevToolsParser(object):
             for request in requests:
                 if 'raw_id' in request and request['raw_id'] in timeline_requests and 'renderBlocking' in timeline_requests[request['raw_id']]:
                     request['renderBlocking'] = timeline_requests[request['raw_id']]['renderBlocking']
+                if 'raw_id' in request and request['raw_id'] in timeline_requests and 'preloadUnused' in timeline_requests[request['raw_id']]:
+                    request['preloadUnused'] = timeline_requests[request['raw_id']]['preloadUnused']
+                if 'raw_id' in request and request['raw_id'] in timeline_requests and 'preloadMismatch' in timeline_requests[request['raw_id']]:
+                    request['preloadMismatch'] = timeline_requests[request['raw_id']]['preloadMismatch']
 
     def process_page_data(self):
         """Walk through the sorted requests and generate the page-level stats"""

--- a/internal/support/trace_parser.py
+++ b/internal/support/trace_parser.py
@@ -225,6 +225,7 @@ class Trace():
                 cat.find('devtools.timeline') >= 0 or \
                 cat.find('blink.feature_usage') >= 0 or \
                 cat.find('blink.user_timing') >= 0 or \
+                cat.find('blink.resource') >= 0 or \
                 cat.find('loading') >= 0 or \
                 cat.find('navigation') >= 0 or \
                 cat.find('rail') >= 0 or \
@@ -303,7 +304,7 @@ class Trace():
                 self.cpu['main_threads'].append(thread)
         if cat == 'netlog' or cat.find('netlog') >= 0:
             self.ProcessNetlogEvent(trace_event)
-        elif cat == 'devtools.timeline' or cat.find('devtools.timeline') >= 0:
+        elif cat == 'devtools.timeline' or cat.find('devtools.timeline') >= 0 or cat.find('blink.resource') >= 0:
             self.ProcessTimelineTraceEvent(trace_event)
         elif cat.find('blink.feature_usage') >= 0:
             self.ProcessFeatureUsageEvent(trace_event)
@@ -526,7 +527,10 @@ class Trace():
                     request['frame'] = trace_event['args']['data']['frame']
                 if 'renderBlocking' in trace_event['args']['data']:
                     request['renderBlocking'] = trace_event['args']['data']['renderBlocking']
-
+            if trace_event['name'] == 'ResourceFetcher::WarnUnusedPreloads':
+                request['preloadUnused'] = 'true'
+            if trace_event['name'] == 'ResourceFetcher::PrintPreloadMismatch':
+                request['preloadMismatch'] = 'true'
         # Build timeline events on a stack. 'B' begins an event, 'E' ends an
         # event
         if (thread in self.threads and (

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -826,7 +826,7 @@ class WebPageTest(object):
                         'profile': profile_dir,
                         'error': None,
                         'log_data': True,
-                        'activity_time': 2,
+                        'activity_time': 3,
                         'combine_steps': False,
                         'video_directories': [],
                         'page_data': {'tester': self.pc_name, 'start_epoch': time.time()},

--- a/testspec.json
+++ b/testspec.json
@@ -1,3 +1,6 @@
 {
-    "browser": "Canary"
+    "browser": "Canary",
+    "axe": 0,
+    "wappalyzer": 0,
+    "debug": 1
 }


### PR DESCRIPTION
This introduces support for the CDP warnings for mismatched and unused preloads. There are a couple things that had to happen.

1. Need to bump the activity time limit to 3 seconds since that's when Chrome fires the unused preload warnings
2. We needed to start watching `blink.resource` by default. It does bloat the trace files a bit, but it doesn't seem to be too obnoxious.
3. Then we needed to watch for the appropriate messages and use those to set flags on the requests themselves.