### PR TITLE
Add support for reporting unused preloads

### DIFF
--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -1122,6 +1122,18 @@ class DevToolsParser(object):
                     request['preloadUnused'] = timeline_requests[request['raw_id']]['preloadUnused']
                 if 'raw_id' in request and request['raw_id'] in timeline_requests and 'preloadMismatch' in timeline_requests[request['raw_id']]:
                     request['preloadMismatch'] = timeline_requests[request['raw_id']]['preloadMismatch']
+            # Loop through the url-keyed timeline requests that don't have a request ID
+            for req_id in timeline_requests:
+                req = timeline_requests[req_id]
+                if 'has_id' in req and not req['has_id'] and 'url' in req:
+                    for request in requests:
+                        if 'full_url' in request and request['full_url'] == req['url']:
+                            if 'renderBlocking' in req:
+                                request['renderBlocking'] = req['renderBlocking']
+                            if 'preloadUnused' in req:
+                                request['preloadUnused'] = req['preloadUnused']
+                            if 'preloadMismatch' in req:
+                                request['preloadMismatch'] = req['preloadMismatch']
 
     def process_page_data(self):
         """Walk through the sorted requests and generate the page-level stats"""

--- a/internal/support/trace_parser.py
+++ b/internal/support/trace_parser.py
@@ -513,11 +513,20 @@ class Trace():
             self.threads[thread] = {}
         
         # Keep track of request events reported by the timeline
+        request_id = None
+        has_id = False
         if 'args' in trace_event and 'data' in trace_event['args'] and 'requestId' in trace_event['args']['data']:
             request_id = trace_event['args']['data']['requestId']
+            has_id = True
+        elif 'args' in trace_event and 'url' in trace_event['args']:
+            request_id = trace_event['args']['url']
+        if request_id is not None:
             if request_id not in self.timeline_requests:
                 self.timeline_requests[request_id] = {}
             request = self.timeline_requests[request_id]
+            request['has_id'] = has_id
+            if 'args' in trace_event and 'url' in trace_event['args']:
+                request['url'] = trace_event['args']['url']
             if trace_event['name'] == 'ResourceSendRequest':
                 if 'priority' in trace_event['args']['data']:
                     request['priority'] = trace_event['args']['data']['priority']


### PR DESCRIPTION
This fixes the unused preload reporting to match on URL if a request ID isn't included with the trace events (the render-blocking events have an ID but the preload ones don't).