### PR TITLE
Fixing headers and other indicators for proxied resources

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -1467,7 +1467,7 @@ class DevTools(object):
                                 params['url'] = url.replace(host, self.task['overrideHosts'][host_match], 1)
                                 # We need to add the new URL to our event for parsing later
                                 # let's use an underscore to indicate to ourselves that we're adding this
-                                msg['params']['_proxiedURL'] =  url.replace(host, self.task['overrideHosts'][host_match], 1)
+                                msg['params']['_overwrittenURL'] =  url.replace(host, self.task['overrideHosts'][host_match], 1)
                             break
                 except Exception:
                     logging.exception('Error processing host override')

--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -1465,6 +1465,9 @@ class DevTools(object):
                                 headers['x-Host'] = host
                                 params['headers'] = headers
                                 params['url'] = url.replace(host, self.task['overrideHosts'][host_match], 1)
+                                # We need to add the new URL to our event for parsing later
+                                # let's use an underscore to indicate to ourselves that we're adding this
+                                msg['params']['_proxiedURL'] =  url.replace(host, self.task['overrideHosts'][host_match], 1)
                             break
                 except Exception:
                     logging.exception('Error processing host override')

--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -193,7 +193,7 @@ class DevToolsParser(object):
                         raw_requests[request_id]['fromCache'] = True
                     if method == 'Network.requestIntercepted' and 'requestId' in params and \
                             request_id is not None and request_id in raw_requests:
-                        raw_requests[request_id]['proxiedURL'] = params['_proxiedURL']
+                        raw_requests[request_id]['overwrittenURL'] = params['_overwrittenURL']
                     # Adjust all of the timestamps to be relative to the start of navigation
                     # and in milliseconds
                     if first_timestamp is None and 'timestamp' in params and \
@@ -474,11 +474,11 @@ class DevToolsParser(object):
                 request['method'] = raw_request['method'] if 'method' in raw_request else ''
                 request['host'] = parts.netloc
                 request['url'] = parts.path
-                if 'proxiedURL' in raw_request:
-                    request['full_url'] = raw_request['proxiedURL']
+                if 'overwrittenURL' in raw_request:
+                    request['full_url'] = raw_request['overwrittenURL']
                     request['original_url'] = raw_request['url']
-                    proxiedURL = raw_request['proxiedURL'].split('#', 1)[0]
-                    parts = urlsplit(proxiedURL)
+                    overwrittenURL = raw_request['overwrittenURL'].split('#', 1)[0]
+                    parts = urlsplit(overwrittenURL)
                     request['host'] = parts.netloc
                     request['url'] = parts.path
                 if 'raw_id' in raw_request:

--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -470,11 +470,17 @@ class DevToolsParser(object):
                 request = {'type': 3, 'id': raw_request['id'], 'request_id': raw_request['id']}
                 request['ip_addr'] = ''
                 request['full_url'] = url
-                request['proxied_url'] = raw_request['proxiedURL'] if 'proxiedURL' in raw_request else ''      
                 request['is_secure'] = 1 if parts.scheme == 'https' else 0
                 request['method'] = raw_request['method'] if 'method' in raw_request else ''
                 request['host'] = parts.netloc
                 request['url'] = parts.path
+                if 'proxiedURL' in raw_request:
+                    request['full_url'] = raw_request['proxiedURL']
+                    request['original_url'] = raw_request['url']
+                    proxiedURL = raw_request['proxiedURL'].split('#', 1)[0]
+                    parts = urlsplit(proxiedURL)
+                    request['host'] = parts.netloc
+                    request['url'] = parts.path
                 if 'raw_id' in raw_request:
                     request['raw_id'] = raw_request['raw_id']
                 if 'frame_id' in raw_request:
@@ -886,8 +892,6 @@ class DevToolsParser(object):
                     for entry in netlog:
                         url_matches = False
                         if 'url' in entry and entry['url'] == request['full_url']:
-                            url_matches = True
-                        elif 'url' in entry and entry['url'] == request['proxied_url']:
                             url_matches = True
                         method_matches = False
                         if 'method' not in entry or 'method' not in request or entry['method'] == request['method']:

--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -191,6 +191,9 @@ class DevToolsParser(object):
                             request_id is not None and request_id in raw_requests:
                         raw_requests[request_id]['fromNet'] = False
                         raw_requests[request_id]['fromCache'] = True
+                    if method == 'Network.requestIntercepted' and 'requestId' in params and \
+                            request_id is not None and request_id in raw_requests:
+                        raw_requests[request_id]['proxiedURL'] = params['_proxiedURL']
                     # Adjust all of the timestamps to be relative to the start of navigation
                     # and in milliseconds
                     if first_timestamp is None and 'timestamp' in params and \
@@ -467,6 +470,7 @@ class DevToolsParser(object):
                 request = {'type': 3, 'id': raw_request['id'], 'request_id': raw_request['id']}
                 request['ip_addr'] = ''
                 request['full_url'] = url
+                request['proxied_url'] = raw_request['proxiedURL'] if 'proxiedURL' in raw_request else ''      
                 request['is_secure'] = 1 if parts.scheme == 'https' else 0
                 request['method'] = raw_request['method'] if 'method' in raw_request else ''
                 request['host'] = parts.netloc
@@ -882,6 +886,8 @@ class DevToolsParser(object):
                     for entry in netlog:
                         url_matches = False
                         if 'url' in entry and entry['url'] == request['full_url']:
+                            url_matches = True
+                        elif 'url' in entry and entry['url'] == request['proxied_url']:
                             url_matches = True
                         method_matches = False
                         if 'method' not in entry or 'method' not in request or entry['method'] == request['method']:

--- a/internal/support/trace_parser.py
+++ b/internal/support/trace_parser.py
@@ -519,8 +519,8 @@ class Trace():
                 self.timeline_requests[request_id] = {}
             request = self.timeline_requests[request_id]
             if trace_event['name'] == 'Network.requestIntercepted':
-                if 'proxiedURL' in trace_event['args']['data']:
-                    request['proxiedURL'] = trace_event['args']['data']['proxiedURL']
+                if 'overwrittenURL' in trace_event['args']['data']:
+                    request['overwrittenURL'] = trace_event['args']['data']['overwrittenURL']
             if trace_event['name'] == 'ResourceSendRequest':
                 if 'priority' in trace_event['args']['data']:
                     request['priority'] = trace_event['args']['data']['priority']

--- a/internal/support/trace_parser.py
+++ b/internal/support/trace_parser.py
@@ -518,6 +518,9 @@ class Trace():
             if request_id not in self.timeline_requests:
                 self.timeline_requests[request_id] = {}
             request = self.timeline_requests[request_id]
+            if trace_event['name'] == 'Network.requestIntercepted':
+                if 'proxiedURL' in trace_event['args']['data']:
+                    request['proxiedURL'] = trace_event['args']['data']['proxiedURL']
             if trace_event['name'] == 'ResourceSendRequest':
                 if 'priority' in trace_event['args']['data']:
                     request['priority'] = trace_event['args']['data']['priority']


### PR DESCRIPTION
This brings back headers, render blocking indicators, unused preloads, etc for URL's that get intercepted thanks to overrideHost