### PR TITLE
Allow for running with arbitrary Chrome extensions

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -159,7 +159,8 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
         while not connected and count < 3:
             count += 1
             DesktopBrowser.launch_browser(self, command_line)
-            DesktopBrowser.wait_for_idle(self)
+            if 'extensions' in job:
+                DesktopBrowser.wait_for_idle(self)
             if DevtoolsBrowser.connect(self, task):
                 connected = True
             elif count < 3:

--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -117,6 +117,23 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
         args.append('--enable-blink-features=' + ','.join(ENABLE_BLINK_FEATURES))
         if task['running_lighthouse']:
             args.append('--headless')
+        
+        if 'extensions' in job:
+            extensions = job['extensions'].split(',')
+            extensions_dir = os.path.join(job['persistent_dir'], 'extensions')
+            paths = ''
+            for extension in extensions:
+                extension = extension.strip()
+                if extension.isalnum():
+                    extension_dir = os.path.join(extensions_dir, extension)
+                    if os.path.exists(extension_dir):
+                        if paths:
+                            paths += ','
+                        paths += extension_dir
+                    else:
+                        self.task['error'] = 'Missing extension: ' + extension
+            if paths:
+                args.append('--load-extension="{}"'.format(paths))
 
         # Disable site isolation if emulating mobile. It is disabled on
         # actual mobile Chrome (and breaks Chrome's CPU throttling)
@@ -142,6 +159,7 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
         while not connected and count < 3:
             count += 1
             DesktopBrowser.launch_browser(self, command_line)
+            DesktopBrowser.wait_for_idle(self)
             if DevtoolsBrowser.connect(self, task):
                 connected = True
             elif count < 3:


### PR DESCRIPTION
This adds logic to the agent where Chrome extensions can be specified with a job (comma-separated list of extension ID's). If extensions are requested, they will be downloaded from the Chrome web store and the browser will be launched with the extension(s) loaded through the command-line.

This is chrome-only (at least for now) and desktop only (mobile emulation included but may not make sense).

The extensions will be cached on the agent for a week by default before re-installing from the web store.  The expiration can be overridden with a `extensions_cache_time` job param from the server (in seconds).  It's probably best not to expose `extensions_cache_time` to the API directly and only load the value out of settings if configured on the server.

The actual extensions list should be safe to expose directly to the Web UI and API. The extension ID is validated to only be alphanumeric (avoid attack vector on the agent command-line) and the extensions themselves are only downloaded from the Chrome web store (and run in the context of the browser, and only when requested).

It may also make sense to expose specific extensions as specific features (block ads uses a selected ad blocker for example).

The additional WaitForIdle after launching the browser but before connecting is because som extensions (adblock for example) pop a new tab when they are first run (which is every time with WPT) and this lets them do their thing so the agent can close the spare tabs before actually starting the test. It won't add overhead in the normal path since it only waits when extensions are used (and even then, it just moves the idle wait earlier and shouldn't be any slower).