### PR TITLE
removed redundant testinfo start time set.

### DIFF
--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -607,7 +607,6 @@ class WebPageTest(object):
                     with open(job_path, 'wt') as f_out:
                         json.dump(job, f_out)
                     self.needs_zip.append({'path': job_path, 'name': 'job.json'})
-                    job['testinfo']['started'] = job['started']
                 # Add the non-serializable members
                 if self.health_check_server is not None:
                     job['health_check_server'] = self.health_check_server


### PR DESCRIPTION
Running with (python3 wptagent.py -vvvv --location test --key 12546 --testurl 'https://google.com' --testspec testspec.json --testout url --xvfb)

job['testinfo']['started'] is caught on exception because 'testinfo' wasn't checked if it was a key first but earlier in the code was a job['testinfo']['started'] = job['started'] at line 579 with the proper check first. So I removed the redundant set.

![No_check for testinfo](https://user-images.githubusercontent.com/33207323/165152668-85fa736f-e2b0-4349-89a0-179ca0532131.png)
