### PR TITLE
Switch pubsub to use streaming

### DIFF
--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -60,7 +60,6 @@ class WebPageTest(object):
         self.fetch_result_queue = multiprocessing.JoinableQueue()
         self.job = None
         self.raw_job = None
-        self.pubsub_job = None
         self.first_failure = None
         self.is_rebooting = False
         self.is_dead = False
@@ -222,11 +221,6 @@ class WebPageTest(object):
         if os.path.isfile(margins_file):
             with open(margins_file, 'r') as f_in:
                 self.margins = json.load(f_in)
-        # pubsub if configured
-        self.subscriber = None
-        if self.options.pubsub:
-            from google.cloud import pubsub_v1
-            self.subscriber = pubsub_v1.SubscriberClient()
         # Load any locally-defined custom metrics from {agent root}/custom/metrics/*.js
         self.custom_metrics = {}
         self.load_local_custom_metrics()
@@ -511,7 +505,10 @@ class WebPageTest(object):
 
     def process_job_json(self, test_json):
         """Process the JSON of a test into a job file"""
+        if self.cpu_scale_multiplier is None:
+            self.benchmark_cpu()
         job = test_json
+        self.raw_job = dict(test_json)
         if job is not None:
             try:
                 logging.debug("Job: %s", json.dumps(job))
@@ -627,14 +624,12 @@ class WebPageTest(object):
 
     def get_test(self, browsers):
         """Get a job from the server"""
-        if self.is_rebooting or self.is_dead:
+        if self.is_rebooting or self.is_dead or self.options.pubsub:
             return
         import requests
         proxies = {"http": None, "https": None}
         from .os_util import get_free_disk_space
-        if self.cpu_scale_multiplier is None:
-            self.benchmark_cpu()
-        if len(self.work_servers) == 0 and len(self.scheduler_nodes) == 0 and not self.options.pubsub:
+        if len(self.work_servers) == 0 and len(self.scheduler_nodes) == 0:
             return None
         job = None
         self.raw_job = None
@@ -696,20 +691,6 @@ class WebPageTest(object):
                     logging.info("Checking for work for node %s: %s", self.scheduler_node, url)
                     response = self.session.get(url, timeout=10, proxies=proxies, headers={'CPID': self.get_cpid(self.scheduler_node)})
                     response_text = response.text if len(response.text) else None
-                elif self.subscriber:
-                    logging.debug('Polling work from pubsub: %s', self.options.pubsub)
-                    try:
-                        from google.cloud import pubsub_v1
-                        response = self.subscriber.pull(request={
-                            'subscription': self.options.pubsub,
-                            'max_messages': 1,
-                            'return_immediately': True,
-                            }, timeout=10)
-                        if len(response.received_messages) == 1:
-                            self.pubsub_job = response.received_messages[0]
-                            response_text = self.pubsub_job.message.data.decode('utf-8')
-                    except Exception:
-                        logging.exception('Error polling from pubsub')
                 else:
                     logging.info("Checking for work: %s", url)
                     response = self.session.get(url, timeout=10, proxies=proxies)
@@ -783,12 +764,6 @@ class WebPageTest(object):
                 location = str(locations.pop(0))
                 count -= 1
                 retry = True
-        if not self.needs_zip:
-            self.needs_zip = []
-        if job is not None and 'work_server' in job and 'jobID' in job:
-            self.notify_test_started(job)
-        self.install_extensions()
-        self.report_diagnostics()
         return job
 
     def notify_test_started(self, job):
@@ -805,6 +780,13 @@ class WebPageTest(object):
         """Create a task object for the next test run or return None if the job is done"""
         if self.is_dead:
             return None
+        # Do the one-time setup at the beginning of a job
+        if 'current_state' not in job:
+            if not self.needs_zip:
+                self.needs_zip = []
+            if 'work_server' in job and 'jobID' in job:
+                self.notify_test_started(job)
+            self.install_extensions()
         self.report_diagnostics()
         task = None
         if self.log_handler is not None:
@@ -1509,26 +1491,18 @@ class WebPageTest(object):
                     self.post_data(self.url + "workdone.php", data, zip_path, 'result.zip')
             
             # See if the job needs to be posted to a retry pubsub queue
-            if self.pubsub_job is not None:
+            if self.options.pubsub:
                 from google.cloud import pubsub_v1
-                if 'pubsub_retry_queue' in self.job and 'success' in self.job and not self.job['success'] and self.pubsub_job is not None:
+                if 'pubsub_retry_queue' in self.job and 'success' in self.job and not self.job['success']:
                     try:
                         from concurrent import futures
                         logging.debug('Sending test to retry queue: %s', self.job['pubsub_retry_queue'])
                         publisher = pubsub_v1.PublisherClient()
-                        publisher_future = publisher.publish(self.job['pubsub_retry_queue'], self.pubsub_job.message.data)
+                        job_str = json.dumps(self.raw_job)
+                        publisher_future = publisher.publish(self.job['pubsub_retry_queue'], job_str.encode())
                         futures.wait([publisher_future], return_when=futures.ALL_COMPLETED)
                     except Exception:
                         logging.exception('Error sending job to pubsub retry queue')
-                if self.subscriber is not None:
-                    try:
-                        self.subscriber.acknowledge(request={
-                            'subscription': self.options.pubsub,
-                            'ack_ids': [self.pubsub_job.ack_id]
-                        })
-                    except Exception:
-                        logging.exception('Error acknowledging pubsub job')
-        self.pubsub_job = None
         self.raw_job = None
         self.needs_zip = []
         # Clean up the work directory
@@ -1887,7 +1861,7 @@ class WebPageTest(object):
         if not self.is_dead:
             self.is_dead = True
             # requeue the raw test through the original server
-            if self.raw_job is not None:
+            if self.raw_job is not None and 'work_server' in self.raw_job:
                 url = self.raw_job['work_server'] + 'requeue.php?id=' + quote_plus(self.raw_job['id'])
                 url += '&sig=' + quote_plus(self.raw_job['signature'])
                 url += '&location=' + quote_plus(self.raw_job['location'])

--- a/wptagent.py
+++ b/wptagent.py
@@ -39,6 +39,7 @@ class WPTAgent(object):
         self.options = options
         self.capture_display = None
         self.health_check_server = None
+        self.message_server = None
         self.job = None
         self.task = None
         self.xvfb = None
@@ -92,12 +93,12 @@ class WPTAgent(object):
         done = False
         exit_file = os.path.join(self.root_path, 'exit')
         shutdown_file = os.path.join(self.root_path, 'shutdown')
-        message_server = None
+        self.message_server = None
         if not self.options.android and not self.options.iOS:
             from internal.message_server import MessageServer
-            message_server = MessageServer()
-            message_server.start()
-            if not message_server.is_ok():
+            self.message_server = MessageServer()
+            self.message_server.start()
+            if not self.message_server.is_ok():
                 logging.error("Unable to start the local message server")
                 return
         if self.options.healthcheckport:
@@ -108,6 +109,20 @@ class WPTAgent(object):
                 logging.error("Unable to start the health check server")
                 return
             self.wpt.health_check_server = self.health_check_server
+    
+        # If we are using a pubsub scription, start the listening thread
+        subscriber = None
+        streaming_pull_future = None
+        if self.options.pubsub:
+            try:
+                from google.cloud import pubsub_v1
+                subscriber = pubsub_v1.SubscriberClient()
+                subscription_path = self.options.pubsub
+                flow_control = pubsub_v1.types.FlowControl(max_messages=1)
+                streaming_pull_future = subscriber.subscribe(subscription_path, callback=self.pubsub_callback, flow_control=flow_control)
+                logging.debug("Listening for messages on %s..", subscription_path)                
+            except Exception:
+                logging.exception('Error starting pubsub subscription')
 
         while not self.must_exit and not done:
             try:
@@ -127,77 +142,43 @@ class WPTAgent(object):
                     self.must_exit = True
                     self.needs_shutdown = True
                     break
-                if message_server is not None and self.options.exit > 0 and not message_server.is_ok():
+                if self.message_server is not None and self.options.exit > 0 and not self.message_server.is_ok():
                     logging.error("Message server not responding, exiting")
                     break
                 if self.health_check_server is not None and self.options.exit > 0 and not self.health_check_server.is_ok():
                     logging.error("Health check server not responding, exiting")
                     break
-                if self.browsers.is_ready():
-                    if self.options.testurl or self.options.testspec:
-                        done = True
-                        try:
-                            test_json = {}
-                            if self.options.testspec:
-                                with open(self.options.testspec, 'rt') as f_in:
-                                    test_json = json.load(f_in)
-                            if self.options.testurl:
-                                test_json['url'] = self.options.testurl
-                            if self.options.browser:
-                                test_json['browser'] = self.options.browser
-                            if 'runs' not in test_json:
-                                test_json['runs'] = self.options.testruns
-                            if 'fvonly' not in test_json:
-                                test_json['fvonly'] = not self.options.testrv
-                            self.job = self.wpt.process_job_json(test_json)
-                        except Exception:
-                            logging.exception('Error processing test options')
-                    else:
-                        self.job = self.wpt.get_test(self.browsers.browsers)
-                    if self.job is not None:
-                        self.job['image_magick'] = self.image_magick
-                        self.job['message_server'] = message_server
-                        self.job['capture_display'] = self.capture_display
-                        self.job['shaper'] = self.shaper
-                        self.task = self.wpt.get_task(self.job)
-                        while self.task is not None:
-                            start = monotonic()
-                            try:
-                                self.task['running_lighthouse'] = False
-                                if self.job['type'] != 'lighthouse':
-                                    self.run_single_test()
-                                    self.wpt.get_bodies(self.task)
-                                if self.task['run'] == 1 and not self.task['cached'] and \
-                                        self.job['warmup'] <= 0 and \
-                                        self.task['error'] is None and \
-                                        'lighthouse' in self.job and self.job['lighthouse']:
-                                    if 'page_result' not in self.task or \
-                                            self.task['page_result'] is None or \
-                                            self.task['page_result'] == 0 or \
-                                            self.task['page_result'] == 99999:
-                                        self.task['running_lighthouse'] = True
-                                        self.wpt.running_another_test(self.task)
-                                        self.run_single_test()
-                                elapsed = monotonic() - start
-                                logging.debug('Test run time: %0.3f sec', elapsed)
-                            except Exception as err:
-                                msg = ''
-                                if err is not None and err.__str__() is not None:
-                                    msg = err.__str__()
-                                self.task['error'] = 'Unhandled exception running test: '\
-                                    '{0}'.format(msg)
-                                logging.exception("Unhandled exception running test: %s", msg)
-                                traceback.print_exc(file=sys.stdout)
-                            self.wpt.upload_task_result(self.task)
-                            # Set up for the next run
-                            self.task = self.wpt.get_task(self.job)
-                        self.output_test_result()
-                elif self.options.exit > 0 and self.browsers.should_exit():
-                    self.must_exit = True
-                if self.job is not None:
-                    self.job = None
-                elif not done and not self.must_exit:
+                if self.options.pubsub:
                     self.sleep(self.options.polling)
+                else:
+                    if self.browsers.is_ready():
+                        if self.options.testurl or self.options.testspec:
+                            done = True
+                            try:
+                                test_json = {}
+                                if self.options.testspec:
+                                    with open(self.options.testspec, 'rt') as f_in:
+                                        test_json = json.load(f_in)
+                                if self.options.testurl:
+                                    test_json['url'] = self.options.testurl
+                                if self.options.browser:
+                                    test_json['browser'] = self.options.browser
+                                if 'runs' not in test_json:
+                                    test_json['runs'] = self.options.testruns
+                                if 'fvonly' not in test_json:
+                                    test_json['fvonly'] = not self.options.testrv
+                                self.job = self.wpt.process_job_json(test_json)
+                            except Exception:
+                                logging.exception('Error processing test options')
+                        else:
+                            self.job = self.wpt.get_test(self.browsers.browsers)
+                        self.run_job()
+                    elif self.options.exit > 0 and self.browsers.should_exit():
+                        self.must_exit = True
+                    if self.job is not None:
+                        self.job = None
+                    elif not done and not self.must_exit:
+                        self.sleep(self.options.polling)
             except Exception as err:
                 msg = ''
                 if err is not None and err.__str__() is not None:
@@ -218,10 +199,76 @@ class WPTAgent(object):
             # Exit if adb is having issues (will cause a reboot after several tries)
             if self.adb is not None and self.adb.needs_exit:
                 done = True
+        # Shut down pubsub
+        if streaming_pull_future:
+            try:
+                streaming_pull_future.cancel()
+                streaming_pull_future.result(timeout=300)
+            except:
+                pass
         self.cleanup()
         if self.needs_shutdown:
             if platform.system() == "Linux":
                 subprocess.call(['sudo', 'poweroff'])
+
+    def pubsub_callback(self, message):
+        """Pubsub callback for jobs"""
+        logging.debug('Received pubsub job')
+        try:
+            test_json = json.loads(message.data.decode('utf-8'))
+            self.job = self.wpt.process_job_json(test_json)
+            self.run_job()
+        except Exception:
+            logging.exception('Error processing pubsub job')
+        message.ack()
+
+    def run_job(self):
+        """Run a single job from start to end"""
+        try:
+            if (sys.version_info >= (3, 0)):
+                from time import monotonic
+            else:
+                from monotonic import monotonic
+            if self.job is not None:
+                self.job['image_magick'] = self.image_magick
+                self.job['message_server'] = self.message_server
+                self.job['capture_display'] = self.capture_display
+                self.job['shaper'] = self.shaper
+                self.task = self.wpt.get_task(self.job)
+                while self.task is not None:
+                    start = monotonic()
+                    try:
+                        self.task['running_lighthouse'] = False
+                        if self.job['type'] != 'lighthouse':
+                            self.run_single_test()
+                            self.wpt.get_bodies(self.task)
+                        if self.task['run'] == 1 and not self.task['cached'] and \
+                                self.job['warmup'] <= 0 and \
+                                self.task['error'] is None and \
+                                'lighthouse' in self.job and self.job['lighthouse']:
+                            if 'page_result' not in self.task or \
+                                    self.task['page_result'] is None or \
+                                    self.task['page_result'] == 0 or \
+                                    self.task['page_result'] == 99999:
+                                self.task['running_lighthouse'] = True
+                                self.wpt.running_another_test(self.task)
+                                self.run_single_test()
+                        elapsed = monotonic() - start
+                        logging.debug('Test run time: %0.3f sec', elapsed)
+                    except Exception as err:
+                        msg = ''
+                        if err is not None and err.__str__() is not None:
+                            msg = err.__str__()
+                        self.task['error'] = 'Unhandled exception running test: '\
+                            '{0}'.format(msg)
+                        logging.exception("Unhandled exception running test: %s", msg)
+                        traceback.print_exc(file=sys.stdout)
+                    self.wpt.upload_task_result(self.task)
+                    # Set up for the next run
+                    self.task = self.wpt.get_task(self.job)
+                self.output_test_result()
+        except Exception:
+            logging.exception('Error running job')
 
     def output_test_result(self):
         """Dump the result of a CLI test to stdout"""


### PR DESCRIPTION
The polling pubsub API falls over pretty quickly and it works a lot better if you set up a long-lived subscriber. Using the synchronous API, it would fall over with just a few hundred clients which kind of defeats the purpose.

This changes the pubsub client logic to use a subscription that can process 1 message at a time instead of the main loop that polls for work.  It required refactoring the main loop to extract the core test-running part into a separate function that can be called by the message callback.

There were also some bugs in the code when a test cam in from the cli (and the new path) where the CPU wasn't benchmarked and extensions wouldn't be installed so I moved that logic into get_task (to run only once per job for the first time through).