### PR TITLE
Fixed two try except unused exception/ logging.Exception which should…

### DIFF
--- a/internal/android_browser.py
+++ b/internal/android_browser.py
@@ -251,8 +251,8 @@ class AndroidBrowser(BaseBrowser):
                         logline = '{0:d},{1:d},-1,-1\n'.format(snapshot['time'], snapshot['bw'])
                         logging.debug(logline)
                         gzfile.write(logline)
-                except Exception:
-                    logging.Exception("Error processing usage queue")
+                except:
+                    logging.exception("Error processing usage queue")
                 gzfile.close()
         if self.tcpdump_enabled:
             tcpdump = os.path.join(task['dir'], task['prefix']) + '.cap'

--- a/internal/android_browser.py
+++ b/internal/android_browser.py
@@ -251,7 +251,7 @@ class AndroidBrowser(BaseBrowser):
                         logline = '{0:d},{1:d},-1,-1\n'.format(snapshot['time'], snapshot['bw'])
                         logging.debug(logline)
                         gzfile.write(logline)
-                except:
+                except Exception:
                     logging.exception("Error processing usage queue")
                 gzfile.close()
         if self.tcpdump_enabled:

--- a/internal/desktop_browser.py
+++ b/internal/desktop_browser.py
@@ -656,7 +656,7 @@ class DesktopBrowser(BaseBrowser):
                             break
                         gzfile.write('{0:d},{1:d},{2:0.2f},-1\n'.format(
                             snapshot['time'], snapshot['bw'], snapshot['cpu']))
-                except:
+                except Exception:
                     logging.exception("Error processing usage queue")
                 gzfile.close()
         if self.tcpdump is not None:

--- a/internal/desktop_browser.py
+++ b/internal/desktop_browser.py
@@ -656,8 +656,8 @@ class DesktopBrowser(BaseBrowser):
                             break
                         gzfile.write('{0:d},{1:d},{2:0.2f},-1\n'.format(
                             snapshot['time'], snapshot['bw'], snapshot['cpu']))
-                except Exception:
-                    logging.Exception("Error processing usage queue")
+                except:
+                    logging.exception("Error processing usage queue")
                 gzfile.close()
         if self.tcpdump is not None:
             logging.debug('Waiting for tcpdump to stop')

--- a/internal/support/visualmetrics.py
+++ b/internal/support/visualmetrics.py
@@ -901,9 +901,7 @@ def frames_match(image1, image2, fuzz_percent,
         if different_pixels <= max_differences:
             match = True
     else:
-        logging.debug(
-            'Unexpected compare result: out: "{0}", err: "{1}"'.format(
-                out, err))
+        logging.debug('Unexpected compare result: err: "{1}"'.format(err))
 
     return match
 

--- a/internal/support/visualmetrics.py
+++ b/internal/support/visualmetrics.py
@@ -901,7 +901,7 @@ def frames_match(image1, image2, fuzz_percent,
         if different_pixels <= max_differences:
             match = True
     else:
-        logging.debug('Unexpected compare result: err: "{1}"'.format(err))
+        logging.debug('Unexpected compare result: err: "{}"'.format(err))
 
     return match
 


### PR DESCRIPTION
… be logging.exception
Minor fixes to reduce the amount of errors shown in Pylint. 
No function is called logging.Exception(), someone most likely meant logging.exception(). I removed the "Exception" as well because it is unused in the except. 