### PR TITLE
Add support for $WPT_URL substitution into custom scripts

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -571,14 +571,14 @@ class DevtoolsBrowser(object):
             accessibility_tree = None
             for name in self.job['customMetrics']:
                 custom_script = unicode(self.job['customMetrics'][name])
-                if custom_script.find('$WPT_URL') >= 0:
+                if custom_script.find('$WPT_TEST_URL') >= 0:
                     wpt_url = 'window.location.href'
                     if 'page_data' in self.task and 'URL' in self.task['page_data']:
                         wpt_url = '{}'.format(json.dumps(self.task['page_data']['URL']))
                     elif 'url' in self.job:
                         wpt_url = '{}'.format(json.dumps(self.job['URL']))
                     try:
-                        custom_script = custom_script.replace('$WPT_URL', wpt_url)
+                        custom_script = custom_script.replace('$WPT_TEST_URL', wpt_url)
                     except Exception:
                         logging.exception('Error substituting URL data into custom script')
                 if custom_script.find('$WPT_REQUESTS') >= 0:

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -581,7 +581,6 @@ class DevtoolsBrowser(object):
                         custom_script = custom_script.replace('$WPT_URL', wpt_url)
                     except Exception:
                         logging.exception('Error substituting URL data into custom script')
-                    logging.debug(custom_script)
                 if custom_script.find('$WPT_REQUESTS') >= 0:
                     if requests is None:
                         requests = self.get_sorted_requests_json(False)

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -571,6 +571,17 @@ class DevtoolsBrowser(object):
             accessibility_tree = None
             for name in self.job['customMetrics']:
                 custom_script = unicode(self.job['customMetrics'][name])
+                if custom_script.find('$WPT_URL') >= 0:
+                    wpt_url = 'window.location.href'
+                    if 'page_data' in self.task and 'URL' in self.task['page_data']:
+                        wpt_url = '{}'.format(json.dumps(self.task['page_data']['URL']))
+                    elif 'url' in self.job:
+                        wpt_url = '{}'.format(json.dumps(self.job['URL']))
+                    try:
+                        custom_script = custom_script.replace('$WPT_URL', wpt_url)
+                    except Exception:
+                        logging.exception('Error substituting URL data into custom script')
+                    logging.debug(custom_script)
                 if custom_script.find('$WPT_REQUESTS') >= 0:
                     if requests is None:
                         requests = self.get_sorted_requests_json(False)

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -553,6 +553,17 @@ class Firefox(DesktopBrowser):
             for name in self.job['customMetrics']:
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
+                if custom_script.find('$WPT_URL') >= 0:
+                    wpt_url = 'window.location.href'
+                    if 'page_data' in self.task and 'URL' in self.task['page_data']:
+                        wpt_url = '{}'.format(json.dumps(self.task['page_data']['URL']))
+                    elif 'url' in self.job:
+                        wpt_url = '{}'.format(json.dumps(self.job['URL']))
+                    try:
+                        custom_script = custom_script.replace('$WPT_URL', wpt_url)
+                    except Exception:
+                        logging.exception('Error substituting URL data into custom script')
+                    logging.debug(custom_script)
                 if custom_script.find('$WPT_REQUESTS') >= 0:
                     if requests is None:
                         requests = self.get_sorted_requests_json(False)

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -563,7 +563,6 @@ class Firefox(DesktopBrowser):
                         custom_script = custom_script.replace('$WPT_URL', wpt_url)
                     except Exception:
                         logging.exception('Error substituting URL data into custom script')
-                    logging.debug(custom_script)
                 if custom_script.find('$WPT_REQUESTS') >= 0:
                     if requests is None:
                         requests = self.get_sorted_requests_json(False)

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -553,14 +553,14 @@ class Firefox(DesktopBrowser):
             for name in self.job['customMetrics']:
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
-                if custom_script.find('$WPT_URL') >= 0:
+                if custom_script.find('$WPT_TEST_URL') >= 0:
                     wpt_url = 'window.location.href'
                     if 'page_data' in self.task and 'URL' in self.task['page_data']:
                         wpt_url = '{}'.format(json.dumps(self.task['page_data']['URL']))
                     elif 'url' in self.job:
                         wpt_url = '{}'.format(json.dumps(self.job['URL']))
                     try:
-                        custom_script = custom_script.replace('$WPT_URL', wpt_url)
+                        custom_script = custom_script.replace('$WPT_TEST_URL', wpt_url)
                     except Exception:
                         logging.exception('Error substituting URL data into custom script')
                 if custom_script.find('$WPT_REQUESTS') >= 0:

--- a/internal/microsoft_edge.py
+++ b/internal/microsoft_edge.py
@@ -743,6 +743,17 @@ class Edge(DesktopBrowser):
             for name in self.job['customMetrics']:
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
+                if custom_script.find('$WPT_URL') >= 0:
+                    wpt_url = 'window.location.href'
+                    if 'page_data' in self.task and 'URL' in self.task['page_data']:
+                        wpt_url = '{}'.format(json.dumps(self.task['page_data']['URL']))
+                    elif 'url' in self.job:
+                        wpt_url = '{}'.format(json.dumps(self.job['URL']))
+                    try:
+                        custom_script = custom_script.replace('$WPT_URL', wpt_url)
+                    except Exception:
+                        logging.exception('Error substituting URL data into custom script')
+                    logging.debug(custom_script)
                 if custom_script.find('$WPT_REQUESTS') >= 0:
                     if requests is None:
                         requests = self.get_sorted_requests_json(False)

--- a/internal/microsoft_edge.py
+++ b/internal/microsoft_edge.py
@@ -743,14 +743,14 @@ class Edge(DesktopBrowser):
             for name in self.job['customMetrics']:
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
-                if custom_script.find('$WPT_URL') >= 0:
+                if custom_script.find('$WPT_TEST_URL') >= 0:
                     wpt_url = 'window.location.href'
                     if 'page_data' in self.task and 'URL' in self.task['page_data']:
                         wpt_url = '{}'.format(json.dumps(self.task['page_data']['URL']))
                     elif 'url' in self.job:
                         wpt_url = '{}'.format(json.dumps(self.job['URL']))
                     try:
-                        custom_script = custom_script.replace('$WPT_URL', wpt_url)
+                        custom_script = custom_script.replace('$WPT_TEST_URL', wpt_url)
                     except Exception:
                         logging.exception('Error substituting URL data into custom script')
                 if custom_script.find('$WPT_REQUESTS') >= 0:

--- a/internal/microsoft_edge.py
+++ b/internal/microsoft_edge.py
@@ -753,7 +753,6 @@ class Edge(DesktopBrowser):
                         custom_script = custom_script.replace('$WPT_URL', wpt_url)
                     except Exception:
                         logging.exception('Error substituting URL data into custom script')
-                    logging.debug(custom_script)
                 if custom_script.find('$WPT_REQUESTS') >= 0:
                     if requests is None:
                         requests = self.get_sorted_requests_json(False)

--- a/internal/safari_ios.py
+++ b/internal/safari_ios.py
@@ -390,14 +390,14 @@ class iWptBrowser(BaseBrowser):
                     continue
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
-                if custom_script.find('$WPT_URL') >= 0:
+                if custom_script.find('$WPT_TEST_URL') >= 0:
                     wpt_url = 'window.location.href'
                     if 'page_data' in self.task and 'URL' in self.task['page_data']:
                         wpt_url = '{}'.format(json.dumps(self.task['page_data']['URL']))
                     elif 'url' in self.job:
                         wpt_url = '{}'.format(json.dumps(self.job['URL']))
                     try:
-                        custom_script = custom_script.replace('$WPT_URL', wpt_url)
+                        custom_script = custom_script.replace('$WPT_TEST_URL', wpt_url)
                     except Exception:
                         logging.exception('Error substituting URL data into custom script')
                 if custom_script.find('$WPT_REQUESTS') >= 0:

--- a/internal/safari_ios.py
+++ b/internal/safari_ios.py
@@ -400,7 +400,6 @@ class iWptBrowser(BaseBrowser):
                         custom_script = custom_script.replace('$WPT_URL', wpt_url)
                     except Exception:
                         logging.exception('Error substituting URL data into custom script')
-                    logging.debug(custom_script)
                 if custom_script.find('$WPT_REQUESTS') >= 0:
                     if requests is None:
                         requests = self.get_sorted_requests_json(False)

--- a/internal/safari_ios.py
+++ b/internal/safari_ios.py
@@ -390,6 +390,17 @@ class iWptBrowser(BaseBrowser):
                     continue
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
+                if custom_script.find('$WPT_URL') >= 0:
+                    wpt_url = 'window.location.href'
+                    if 'page_data' in self.task and 'URL' in self.task['page_data']:
+                        wpt_url = '{}'.format(json.dumps(self.task['page_data']['URL']))
+                    elif 'url' in self.job:
+                        wpt_url = '{}'.format(json.dumps(self.job['URL']))
+                    try:
+                        custom_script = custom_script.replace('$WPT_URL', wpt_url)
+                    except Exception:
+                        logging.exception('Error substituting URL data into custom script')
+                    logging.debug(custom_script)
                 if custom_script.find('$WPT_REQUESTS') >= 0:
                     if requests is None:
                         requests = self.get_sorted_requests_json(False)

--- a/internal/safari_webdriver.py
+++ b/internal/safari_webdriver.py
@@ -444,6 +444,17 @@ class SafariWebDriver(DesktopBrowser):
             for name in self.job['customMetrics']:
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
+                if custom_script.find('$WPT_URL') >= 0:
+                    wpt_url = 'window.location.href'
+                    if 'page_data' in self.task and 'URL' in self.task['page_data']:
+                        wpt_url = '{}'.format(json.dumps(self.task['page_data']['URL']))
+                    elif 'url' in self.job:
+                        wpt_url = '{}'.format(json.dumps(self.job['URL']))
+                    try:
+                        custom_script = custom_script.replace('$WPT_URL', wpt_url)
+                    except Exception:
+                        logging.exception('Error substituting URL data into custom script')
+                    logging.debug(custom_script)
                 if custom_script.find('$WPT_REQUESTS') >= 0:
                     if requests is None:
                         requests = self.get_sorted_requests_json(False)

--- a/internal/safari_webdriver.py
+++ b/internal/safari_webdriver.py
@@ -454,7 +454,6 @@ class SafariWebDriver(DesktopBrowser):
                         custom_script = custom_script.replace('$WPT_URL', wpt_url)
                     except Exception:
                         logging.exception('Error substituting URL data into custom script')
-                    logging.debug(custom_script)
                 if custom_script.find('$WPT_REQUESTS') >= 0:
                     if requests is None:
                         requests = self.get_sorted_requests_json(False)

--- a/internal/safari_webdriver.py
+++ b/internal/safari_webdriver.py
@@ -444,14 +444,14 @@ class SafariWebDriver(DesktopBrowser):
             for name in self.job['customMetrics']:
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
-                if custom_script.find('$WPT_URL') >= 0:
+                if custom_script.find('$WPT_TEST_URL') >= 0:
                     wpt_url = 'window.location.href'
                     if 'page_data' in self.task and 'URL' in self.task['page_data']:
                         wpt_url = '{}'.format(json.dumps(self.task['page_data']['URL']))
                     elif 'url' in self.job:
                         wpt_url = '{}'.format(json.dumps(self.job['URL']))
                     try:
-                        custom_script = custom_script.replace('$WPT_URL', wpt_url)
+                        custom_script = custom_script.replace('$WPT_TEST_URL', wpt_url)
                     except Exception:
                         logging.exception('Error substituting URL data into custom script')
                 if custom_script.find('$WPT_REQUESTS') >= 0:


### PR DESCRIPTION
For the HTTP Archive crawl custom metric, we need to make sure the links we extract are in the same origin as the page we originally navigated to (ignoring redirects). This allows for passing the WPT-navigated test URL through to custom metrics as an additional substitution (docs will be updated separately).