### PR TITLE
Added support for posting successful tests to pubsub

### DIFF
--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -1503,6 +1503,18 @@ class WebPageTest(object):
                         futures.wait([publisher_future], return_when=futures.ALL_COMPLETED)
                     except Exception:
                         logging.exception('Error sending job to pubsub retry queue')
+                elif 'pubsub_completed_queue' in self.job and self.job.get('success'):
+                    try:
+                        from concurrent import futures
+                        logging.debug('Sending test to completed queue: %s', self.job['pubsub_completed_queue'])
+                        publisher = pubsub_v1.PublisherClient()
+                        if 'results' in self.job:
+                            self.raw_job['results'] = self.job['results']
+                        job_str = json.dumps(self.raw_job)
+                        publisher_future = publisher.publish(self.job['pubsub_completed_queue'], job_str.encode())
+                        futures.wait([publisher_future], return_when=futures.ALL_COMPLETED)
+                    except Exception:
+                        logging.exception('Error sending job to pubsub completed queue')
         self.raw_job = None
         self.needs_zip = []
         # Clean up the work directory

--- a/wptagent.py
+++ b/wptagent.py
@@ -119,7 +119,7 @@ class WPTAgent(object):
                 subscriber = pubsub_v1.SubscriberClient()
                 subscription_path = self.options.pubsub
                 flow_control = pubsub_v1.types.FlowControl(max_messages=1)
-                streaming_pull_future = subscriber.subscribe(subscription_path, callback=self.pubsub_callback, flow_control=flow_control)
+                streaming_pull_future = subscriber.subscribe(subscription_path, callback=self.pubsub_callback, flow_control=flow_control, await_callbacks_on_shutdown=True)
                 logging.debug("Listening for messages on %s..", subscription_path)                
             except Exception:
                 logging.exception('Error starting pubsub subscription')


### PR DESCRIPTION
This adds support for 2 new test job options:

`pubsub_completed_queue` - A pub/sub queue where successfully completed test jobs are posted to (failures need to have a retry queue configured)
`pubsub_completed_metrics` - A list of metrics to include from the page data in the pubsub job (minimal set of just the metrics needed for the automation)

In the HA case, we pass the top-level URLs with some metadata indicating that they are top-level and configure them to write successful results to a pub/sub queue along with our custom metric `crawl_links` which is a priority-sorted list of same-origin links in the viewport.

The jobs then get resubmitted by a central controller that monitors the queues. It decides how many links to visit, generates new test ID's and submits the new actual tests (without a completion queue configured since we don't want to crawl another layer deeper).