### PR TITLE
import cgi.escape Deprecated since 3.2+ html.escape is 3.2+

### DIFF
--- a/internal/message_server.py
+++ b/internal/message_server.py
@@ -72,9 +72,9 @@ class TornadoRequestHandler(tornado.web.RequestHandler):
             response += "</style>\n"
             response += "</head><body><div id='wptorange'></div>\n"
             if MESSAGE_SERVER.config is not None:
-                import cgi
+                import html
                 response += '<div id="wptagentConfig" style="display: none;">'
-                response += cgi.escape(json.dumps(MESSAGE_SERVER.config))
+                response += html.escape(json.dumps(MESSAGE_SERVER.config))
                 response += '</div>'
             response += "</body></html>"
         elif self.request.uri == '/wpt-start-recording':


### PR DESCRIPTION
@pmeenan  Let me know what you think of this switch.

Looking through Pylint errors I saw that cgi.escape didn't have a defined function called escape. Looking into it further, cgi.escape is deprecated since version 3.2 and html.escape takes its place 3.2+. 

https://github.com/PyCQA/bandit/issues/338

![cgi escape()](https://user-images.githubusercontent.com/33207323/167662257-7beb1480-4389-4cf5-9130-5889d3d777ef.png)

https://stackoverflow.com/questions/20918146/how-to-do-html-escaping-in-python
![cgi-dep](https://user-images.githubusercontent.com/33207323/167663205-c5111567-5b16-4b24-8582-2a7b6b1de77f.png)

