### PR TITLE
Fix font detection for TrueType fonts and extracting metadata from TrueType collections

### DIFF
--- a/internal/font_metadata.py
+++ b/internal/font_metadata.py
@@ -99,7 +99,7 @@ def _read_codepoint_glyph_counts(ttf):
 
 
 def read_metadata(font):
-    ttf = TTFont(font, lazy=True)
+    ttf = TTFont(font, fontNumber=0, lazy=True)
     try:
         ttf.getGlyphNames()
     except Exception:

--- a/internal/optimization_checks.py
+++ b/internal/optimization_checks.py
@@ -1268,7 +1268,7 @@ class OptimizationChecks(object):
             content_type = 'webp'
         elif raw_bytes[:4] == b'OTTO':
             content_type = 'OTF'
-        elif raw_bytes[:4] == b'ttcf':
+        elif raw_bytes[:4] == b'ttcf' or hex_bytes[0:8] == b'00010000':
             content_type = 'TTF'
         elif raw_bytes[:4] == b'wOFF':
             content_type = 'WOFF'


### PR DESCRIPTION
This PR fixes two bugs:

* The signature for TrueType (TTF) files is `0x00010000` ([source](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory)), but the content sniffer used `0x74746366` (`ttcf`; [source](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)) which is only used for TrueType Collections (TTC). TrueType Collections are one or more regular TTF files combined in a single file with some optimisations for shared data. While TrueType Collections are supported by some browsers their use is much lower than regular TrueType and OpenType files. This will result in new data on TTF font files that were previously skipped.
* If a TrueType Collection is passed to the font metadata extractor it will raise an error because the code didn't specify which TrueType file inside the collection should be parsed. To fix this, the metadata extractor will now always read the "default" font in a TrueType Collection (at index 0.) The `fontNumber` parameter is ignored by Fonttools for regular WOFF, WOFF2, TTF, and OTF fonts, so this is a safe change. This will likely result in fewer error messages during a run and some new data on TrueType Collection usage.