### PR TITLE
Added support for Chrome's native script injection

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -1404,7 +1404,8 @@ class DevTools(object):
                 'frame' in msg['params'] and 'id' in msg['params']['frame']:
             if self.main_frame is not None and \
                     self.main_frame == msg['params']['frame']['id'] and\
-                    'injectScript' in self.job:
+                    'injectScript' in self.job and \
+                    not self.job.get('injectScriptAllFrames'):
                 self.execute_js(self.job['injectScript'])
         elif event == 'frameStoppedLoading' and 'params' in msg and 'frameId' in msg['params']:
             if self.main_frame is not None and \

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -129,6 +129,21 @@ class DevtoolsBrowser(object):
                 disable_images.append('jxl')
             if len(disable_images):
                 self.devtools.send_command("Emulation.setDisabledImageTypes", {"imageTypes": disable_images}, wait=True)
+            
+            # Global script injection (server-provided as well as any locally-defined scripts)
+            if 'injectScript' in self.job and self.job.get('injectScriptAllFrames'):
+                self.devtools.send_command("Page.addScriptToEvaluateOnNewDocument", {"source": self.job['injectScript']}, wait=True)
+            inject_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'custom', 'inject')
+            if (os.path.isdir(inject_dir)):
+                files = glob.glob(inject_dir + '/*.js')
+                for file in files:
+                    try:
+                        with open(file, 'rt') as f:
+                            inject_script = f.read()
+                            if inject_script:
+                                self.devtools.send_command("Page.addScriptToEvaluateOnNewDocument", {"source": inject_script}, wait=True)
+                    except Exception:
+                        pass
 
             # Mobile Emulation
             if not self.options.android and not self.is_webkit and \


### PR DESCRIPTION
This adds support for a boolean option `injectScriptAllFrames` that switches the normal best-effort script injection to use Chrome's native support (which injects into all frames, not just the document but guarantees execution before any page scripts).

Fixes https://github.com/WPO-Foundation/wptagent/issues/514