### PR TITLE
Fixed centos_install.sh, tested on centos 7 on google cloud

### DIFF
--- a/centos_install.sh
+++ b/centos_install.sh
@@ -27,7 +27,7 @@ until python3 -m pip install --user -r .github/workflows/requirements.txt
 do
     sleep 1
 done
-curl --silent --location https://rpm.nodesource.com/setup_9.x | sudo bash -
+curl --silent --location https://rpm.nodesource.com/setup_16.x | sudo bash -
 until sudo yum -y install nodejs
 do
     sleep 1

--- a/centos_install.sh
+++ b/centos_install.sh
@@ -17,13 +17,13 @@ until sudo yum groupinstall -y development
 do
     sleep 1
 done
-until sudo yum install -y python27 python-pip ImageMagick ffmpeg Xvfb dbus-x11 libcgroup libcgroup-tools traceroute tcpdump psmisc python-devel google-noto*
+until sudo yum install -y gcc-c++ python3 python3-devel ImageMagick ffmpeg Xvfb dbus-x11 libcgroup libcgroup-tools traceroute tcpdump psmisc python-devel
 do
     sleep 1
 done
 sudo dbus-uuidgen --ensure
-sudo pip install --upgrade pip
-until sudo pip install dnspython monotonic pillow psutil requests ujson tornado xvfbwrapper marionette_driver future
+python3 -m pip install --upgrade --user pip
+until python3 -m pip install --user -r .github/workflows/requirements.txt 
 do
     sleep 1
 done
@@ -52,3 +52,7 @@ echo 'net.ipv4.tcp_syn_retries = 4' | sudo tee -a /etc/sysctl.d/50-wptagent.conf
 sudo fc-cache -f -v
 sudo sysctl -p
 echo 'Reboot is recommended before starting testing'
+
+# Running command used to test
+# python3 wptagent.py -vvvv --xvfb --dockerized --testurl www.google.com
+


### PR DESCRIPTION
Let me know if you need anymore information or for me to test run a different command.
- switch to python3
- gcc-g++ and python3-devel required by google cloud libs
- switched pip install to look at the requirment.txt so we can have a single location for updating library requirements


Command used to test if its working.
![centos7](https://user-images.githubusercontent.com/33207323/170339230-920ee3e3-7eaf-4d71-8bfc-ac05d3829194.png)

What I deemed to be a successful run
![centosResults](https://user-images.githubusercontent.com/33207323/170339236-8fbd30e1-94ec-4aee-9632-859b47428088.png)

After Running ./centos_install.sh
![done install](https://user-images.githubusercontent.com/33207323/170339955-ef1da140-b70a-44c3-b799-5d1165caf41a.png)

@pmeenan or @tkadlec It seems that centos installs a specific version of node JS. Should I update this to a newer version? or is this specific version required?

![warning](https://user-images.githubusercontent.com/33207323/170340467-c3dc0cf3-837f-4732-8b55-60e927e12f51.png)