### PR TITLE
Sorted execution of custom metrics

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -1358,10 +1358,12 @@ class DevTools(object):
         if message is not None:
             if 'text' in message and message['text'].startswith('wptagent_message:'):
                 try:
-                    wpt_message = json.loads(message['text'][17:])
-                    if 'name' in wpt_message:
-                        if wpt_message['name'] == 'perfentry' and 'data' in wpt_message:
-                            self.performance_timing.append(wpt_message['data'])
+                    # Throw away messages over 1MB to prevent things from spiraling too badly
+                    if len(message['text']) < 1000000:
+                        wpt_message = json.loads(message['text'][17:])
+                        if 'name' in wpt_message:
+                            if wpt_message['name'] == 'perfentry' and 'data' in wpt_message:
+                                self.performance_timing.append(wpt_message['data'])
                 except Exception:
                     logging.exception('Error decoding console log message')
             else:

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -584,7 +584,8 @@ class DevtoolsBrowser(object):
             requests = None
             bodies = None
             accessibility_tree = None
-            for name in self.job['customMetrics']:
+            for name in sorted(self.job['customMetrics']):
+                logging.debug('Collecting custom metric %s', name)
                 custom_script = unicode(self.job['customMetrics'][name])
                 if custom_script.find('$WPT_TEST_URL') >= 0:
                     wpt_url = 'window.location.href'

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -551,7 +551,7 @@ class Firefox(DesktopBrowser):
             custom_metrics = {}
             requests = None
             bodies = None
-            for name in self.job['customMetrics']:
+            for name in sorted(self.job['customMetrics']):
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
                 if custom_script.find('$WPT_TEST_URL') >= 0:

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -537,16 +537,6 @@ class Firefox(DesktopBrowser):
         """Collect all of the in-page browser metrics that we need"""
         if self.must_exit:
             return
-        logging.debug("Collecting user timing metrics")
-        user_timing = self.run_js_file('user_timing.js')
-        if user_timing is not None:
-            path = os.path.join(task['dir'], task['prefix'] + '_timed_events.json.gz')
-            with gzip.open(path, GZIP_TEXT, 7) as outfile:
-                outfile.write(json.dumps(user_timing))
-        logging.debug("Collecting page-level metrics")
-        page_data = self.run_js_file('page_data.js')
-        if page_data is not None:
-            task['page_data'].update(page_data)
         if 'customMetrics' in self.job:
             custom_metrics = {}
             requests = None
@@ -588,6 +578,16 @@ class Firefox(DesktopBrowser):
             path = os.path.join(task['dir'], task['prefix'] + '_metrics.json.gz')
             with gzip.open(path, GZIP_TEXT, 7) as outfile:
                 outfile.write(json.dumps(custom_metrics))
+        logging.debug("Collecting user timing metrics")
+        user_timing = self.run_js_file('user_timing.js')
+        if user_timing is not None:
+            path = os.path.join(task['dir'], task['prefix'] + '_timed_events.json.gz')
+            with gzip.open(path, GZIP_TEXT, 7) as outfile:
+                outfile.write(json.dumps(user_timing))
+        logging.debug("Collecting page-level metrics")
+        page_data = self.run_js_file('page_data.js')
+        if page_data is not None:
+            task['page_data'].update(page_data)
 
     def process_message(self, message):
         """Process a message from the extension"""

--- a/internal/microsoft_edge.py
+++ b/internal/microsoft_edge.py
@@ -740,7 +740,7 @@ class Edge(DesktopBrowser):
             custom_metrics = {}
             requests = None
             bodies = None
-            for name in self.job['customMetrics']:
+            for name in sorted(self.job['customMetrics']):
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
                 if custom_script.find('$WPT_TEST_URL') >= 0:

--- a/internal/microsoft_edge.py
+++ b/internal/microsoft_edge.py
@@ -724,17 +724,6 @@ class Edge(DesktopBrowser):
         # Trigger a message to start writing the interactive periods asynchronously
         if self.supports_interactive:
             self.execute_js('window.postMessage({ wptagent: "GetInteractivePeriods"}, "*");')
-        # Collect teh regular browser metrics
-        logging.debug("Collecting user timing metrics")
-        user_timing = self.run_js_file('user_timing.js')
-        if user_timing is not None:
-            path = os.path.join(task['dir'], task['prefix'] + '_timed_events.json.gz')
-            with gzip.open(path, GZIP_TEXT, 7) as outfile:
-                outfile.write(json.dumps(user_timing))
-        logging.debug("Collecting page-level metrics")
-        page_data = self.run_js_file('page_data.js')
-        if page_data is not None:
-            task['page_data'].update(page_data)
         if 'customMetrics' in self.job:
             self.driver.set_script_timeout(30)
             custom_metrics = {}
@@ -777,6 +766,17 @@ class Edge(DesktopBrowser):
             path = os.path.join(task['dir'], task['prefix'] + '_metrics.json.gz')
             with gzip.open(path, GZIP_TEXT, 7) as outfile:
                 outfile.write(json.dumps(custom_metrics))
+        # Collect the regular browser metrics
+        logging.debug("Collecting user timing metrics")
+        user_timing = self.run_js_file('user_timing.js')
+        if user_timing is not None:
+            path = os.path.join(task['dir'], task['prefix'] + '_timed_events.json.gz')
+            with gzip.open(path, GZIP_TEXT, 7) as outfile:
+                outfile.write(json.dumps(user_timing))
+        logging.debug("Collecting page-level metrics")
+        page_data = self.run_js_file('page_data.js')
+        if page_data is not None:
+            task['page_data'].update(page_data)
         # Wait for the interactive periods to be written
         if self.supports_interactive:
             end_time = monotonic() + 10

--- a/internal/process_test.py
+++ b/internal/process_test.py
@@ -451,7 +451,9 @@ class ProcessTest(object):
                                                 if 'region_rects' in event['args']['data']:
                                                     shift['rects'] = event['args']['data']['region_rects']
                                                 if 'sources' in event['args']['data']:
-                                                    shift['sources'] = event['args']['data']['sources']
+                                                    sources_str = json.dumps(event['args']['data']['sources'])
+                                                    if len(sources_str) < 1000000:
+                                                        shift['sources'] = event['args']['data']['sources']
                                                 layout_shifts.append(shift)
 
                                         if name is not None and time is not None and name not in largest:

--- a/internal/safari_ios.py
+++ b/internal/safari_ios.py
@@ -369,18 +369,6 @@ class iWptBrowser(BaseBrowser):
         """Collect all of the in-page browser metrics that we need"""
         if self.must_exit:
             return
-        logging.debug("Collecting user timing metrics")
-        user_timing = self.run_js_file('user_timing.js')
-        logging.debug(user_timing)
-        if user_timing is not None and self.path_base is not None:
-            path = self.path_base + '_timed_events.json.gz'
-            with gzip.open(path, GZIP_TEXT, 7) as outfile:
-                outfile.write(json.dumps(user_timing))
-        logging.debug("Collecting page-level metrics")
-        page_data = self.run_js_file('page_data.js')
-        logging.debug(page_data)
-        if page_data is not None:
-            task['page_data'].update(page_data)
         if 'customMetrics' in self.job:
             custom_metrics = {}
             requests = None
@@ -425,6 +413,18 @@ class iWptBrowser(BaseBrowser):
                 path = self.path_base + '_metrics.json.gz'
                 with gzip.open(path, GZIP_TEXT, 7) as outfile:
                     outfile.write(json.dumps(custom_metrics))
+        logging.debug("Collecting user timing metrics")
+        user_timing = self.run_js_file('user_timing.js')
+        logging.debug(user_timing)
+        if user_timing is not None and self.path_base is not None:
+            path = self.path_base + '_timed_events.json.gz'
+            with gzip.open(path, GZIP_TEXT, 7) as outfile:
+                outfile.write(json.dumps(user_timing))
+        logging.debug("Collecting page-level metrics")
+        page_data = self.run_js_file('page_data.js')
+        logging.debug(page_data)
+        if page_data is not None:
+            task['page_data'].update(page_data)
 
     def process_message(self, msg):
         """Process a message from the browser

--- a/internal/safari_ios.py
+++ b/internal/safari_ios.py
@@ -385,7 +385,7 @@ class iWptBrowser(BaseBrowser):
             custom_metrics = {}
             requests = None
             bodies = None
-            for name in self.job['customMetrics']:
+            for name in sorted(self.job['customMetrics']):
                 if name == 'jsLibsVulns':
                     continue
                 logging.debug("Collecting custom metric %s", name)

--- a/internal/safari_webdriver.py
+++ b/internal/safari_webdriver.py
@@ -441,7 +441,7 @@ class SafariWebDriver(DesktopBrowser):
             custom_metrics = {}
             requests = None
             bodies = None
-            for name in self.job['customMetrics']:
+            for name in sorted(self.job['customMetrics']):
                 logging.debug("Collecting custom metric %s", name)
                 custom_script = unicode(self.job['customMetrics'][name])
                 if custom_script.find('$WPT_TEST_URL') >= 0:

--- a/internal/safari_webdriver.py
+++ b/internal/safari_webdriver.py
@@ -427,16 +427,6 @@ class SafariWebDriver(DesktopBrowser):
         """Collect all of the in-page browser metrics that we need"""
         if self.must_exit:
             return
-        logging.debug("Collecting user timing metrics")
-        user_timing = self.run_js_file('user_timing.js')
-        if user_timing is not None:
-            path = os.path.join(task['dir'], task['prefix'] + '_timed_events.json.gz')
-            with gzip.open(path, GZIP_TEXT, 7) as outfile:
-                outfile.write(json.dumps(user_timing))
-        logging.debug("Collecting page-level metrics")
-        page_data = self.run_js_file('page_data.js')
-        if page_data is not None:
-            task['page_data'].update(page_data)
         if 'customMetrics' in self.job:
             custom_metrics = {}
             requests = None
@@ -478,6 +468,16 @@ class SafariWebDriver(DesktopBrowser):
             path = os.path.join(task['dir'], task['prefix'] + '_metrics.json.gz')
             with gzip.open(path, GZIP_TEXT, 7) as outfile:
                 outfile.write(json.dumps(custom_metrics))
+        logging.debug("Collecting user timing metrics")
+        user_timing = self.run_js_file('user_timing.js')
+        if user_timing is not None:
+            path = os.path.join(task['dir'], task['prefix'] + '_timed_events.json.gz')
+            with gzip.open(path, GZIP_TEXT, 7) as outfile:
+                outfile.write(json.dumps(user_timing))
+        logging.debug("Collecting page-level metrics")
+        page_data = self.run_js_file('page_data.js')
+        if page_data is not None:
+            task['page_data'].update(page_data)
 
     def process_message(self, message):
         """Process a message from the extension"""

--- a/internal/support/chrome/inject.js
+++ b/internal/support/chrome/inject.js
@@ -1,6 +1,9 @@
 var WptAgentFlatten = function(object) {
     let contents = {}
     for (const key in object) {
+        if (key == 'children') {
+            continue;
+        }
         if (typeof(object[key]) === 'object') {
             if (Array.isArray(object[key])) {
                 let values = [];

--- a/internal/support/chrome/inject.js
+++ b/internal/support/chrome/inject.js
@@ -1,6 +1,5 @@
 var WptAgentFlatten = function(object) {
     let contents = {}
-    const ignore = ['innerText', 'outerText', 'innerHTML','textContent', 'baseURI', 'namespaceURI'];
     for (const key in object) {
         if (typeof(object[key]) === 'object') {
             if (Array.isArray(object[key])) {
@@ -13,7 +12,7 @@ var WptAgentFlatten = function(object) {
                     }
                 }
                 contents[key] = values;
-            } else if (['element', 'node', 'currentRect', 'previousRect'].indexOf(key) >= 0) {
+            } else if (key == 'element' || key == 'node' || key == 'currentRect' || key == 'previousRect') {
                 contents[key] = WptAgentFlatten(object[key]);
                 if (typeof object[key]['getBoundingClientRect'] === 'function') {
                     contents[key]['boundingRect'] =  object[key].getBoundingClientRect();
@@ -29,15 +28,17 @@ var WptAgentFlatten = function(object) {
                 }
             }
         } else if (typeof(object[key]) === 'string') {
-            if (object[key].length > 0 && ignore.indexOf(key) === -1) {
-                if (object[key].substring(0,4) == 'http') {
-                    contents[key] = object[key];
-                } else {
-                    contents[key] = object[key].substring(0,200);
-                }
+            if (object[key].length > 0 &&
+                    key != 'innerText' &&
+                    key != 'outerText' &&
+                    key != 'innerHTML' &&
+                    key != 'textContent' &&
+                    key != 'baseURI' &&
+                    key != 'namespaceURI') {
+                contents[key] = object[key];
             }
         } else if (typeof(object[key]) !== 'function') {
-            if (!key.match(/^[A-Z_]+$/)) {
+            if (!/^[A-Z_]+$/.test(key)) {
                 contents[key] = object[key];
             }
         }


### PR DESCRIPTION
* Moves the script injection to be the last thing that happens before a test starts
* Collects the custom metrics in order sorted by name (allows for deterministic ordering of side-effects)
* Prevents recursively spiraling out of control for the CLS elements extraction