### PR TITLE
Improve sorting of requests sent within the same millisecond

### DIFF
--- a/internal/support/netlog.py
+++ b/internal/support/netlog.py
@@ -416,7 +416,7 @@ class Netlog():
         # millisecond is still correct.
         for request in requests:
             if 'start' in request and 'netlog_id' in request:
-                request['start'] = float(request['start']) + (float(request['netlog_id'] % 1000) / 1000000.0)
+                request['start'] = float(request['start']) + (float(request['netlog_id'] % 10000) / 1000000.0)
         self.netlog_requests = requests
         return requests
 

--- a/internal/support/netlog.py
+++ b/internal/support/netlog.py
@@ -140,6 +140,7 @@ class Netlog():
         if 'url_request' in self.netlog:
             for request_id in self.netlog['url_request']:
                 request = self.netlog['url_request'][request_id]
+                request['netlog_id'] = request_id
                 request['fromNet'] = bool('start' in request)
                 if 'start' in request and request['start'] > last_time:
                     last_time = request['start']
@@ -410,6 +411,12 @@ class Netlog():
                     requests = []
         if not len(requests):
             requests = None
+        # Add the netlog request ID as a nanosecond addition to the start time
+        # so that sorting by start time for requests that start within the same
+        # millisecond is still correct.
+        for request in requests:
+            if 'start' in request and 'netlog_id' in request:
+                request['start'] = float(request['start']) + (float(request['netlog_id'] % 1000) / 1000000.0)
         self.netlog_requests = requests
         return requests
 


### PR DESCRIPTION
The old trace-based netlog had sub-millisecond timing data so even requests sent all within the same millisecond would sort correctly (WPT keeps a start_time_float with the full start time for sorting pourposes).

The actual netlog has 1ms timing granularity on the event timestamps so the display of requests sent within the same millisecond can be random instead of the actual order the requests were sent.

WPT sorts the request by send time rather than request ID because prioritization and scheduling can cause browsers to send requests out of order from when they were discovered.

This patch adds the request ID (modulo 10000) as a nanosecond timestamp to the millisecond from the netlog to synthesize a float start time that will sort by request ID within the same millisecond while still not changing the reported start time.  There is an extreme edge case where the request ID's wrap over 10000 within a millisecond boundary but that is unlikely enough to happen that it's not a problem worth adding additional complexity to solve.

For example, [this](https://www.webpagetest.org/result/220701_AiDc2C_FVK/2/details/#waterfall_view_step1) test on production shows 2 of the fonts loading before the css but the preloads are at the end of the head and the actual request order is that they were sent after the CSS.  It's just that they were all emitted within the same millisecond.

![Screen Shot 2022-07-05 at 10 23 24 AM](https://user-images.githubusercontent.com/444165/177350903-f02ad622-e08b-4085-a846-e5c13ec22d72.png)

[Here](https://wpt.meenan.us/result/220705_NW_2/1/details/#waterfall_view_step1) is the same test on my dev server (different connection speed but works for demonstration) that has all of the head requests sent within the same millisecond but has them sorted in the correct order. The second font was actually sent second even though the response came back after the 3rd font.

![Screen Shot 2022-07-05 at 10 25 16 AM](https://user-images.githubusercontent.com/444165/177351196-27ad95fb-9cbc-4690-ab5b-d55cf4de923d.png)