### PR TITLE
New way to create hostname-ipaddress

### DIFF
--- a/internal/os_util.py
+++ b/internal/os_util.py
@@ -131,6 +131,10 @@ def get_file_version(filename):
     return version
 
 def pc_name():
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-        s.connect(("8.8.8.8", 80))
-        return socket.gethostname() + "-" + s.getsockname()[0]
+    """ Grabs the hostname and Local IP address of the machine and returns hostname-IP """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return socket.gethostname() + "-" + s.getsockname()[0]
+    except Exception as e:
+        logging.error("Error getting pc_name: ", e)

--- a/internal/os_util.py
+++ b/internal/os_util.py
@@ -138,3 +138,5 @@ def pc_name():
             return socket.gethostname() + "-" + s.getsockname()[0]
     except Exception as e:
         logging.error("Error getting pc_name: ", e)
+        
+    return platform.uname()[1]

--- a/internal/os_util.py
+++ b/internal/os_util.py
@@ -8,6 +8,7 @@ import logging
 import os
 import platform
 import subprocess
+import socket
 
 def kill_all(exe, force, timeout=30):
     """Terminate all instances of the given process"""
@@ -128,3 +129,8 @@ def get_file_version(filename):
     except:
         logging.exception('Error getting file version for %s', filename)
     return version
+
+def pc_name():
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.connect(("8.8.8.8", 80))
+        return socket.gethostname() + "-" + s.getsockname()[0]

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -105,8 +105,6 @@ class WebPageTest(object):
         self.last_diagnostics = None
         self.time_limit = 120
         self.cpu_scale_multiplier = None
-        # get the hostname or build one automatically if we are on a vmware system
-        # (specific MAC address range)
         self.pc_name = os_util.pc_name() if options.name is None else options.name
         self.auth_name = options.username
         self.auth_password = options.password if options.password is not None else ''

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -24,6 +24,8 @@ import threading
 import time
 import zipfile
 import psutil
+from internal import os_util
+
 if (sys.version_info >= (3, 0)):
     from time import monotonic
     from urllib.parse import quote_plus # pylint: disable=import-error
@@ -105,30 +107,7 @@ class WebPageTest(object):
         self.cpu_scale_multiplier = None
         # get the hostname or build one automatically if we are on a vmware system
         # (specific MAC address range)
-        hostname = platform.uname()[1]
-        interfaces = psutil.net_if_addrs()
-        if interfaces is not None:
-            logging.debug('Interfaces:')
-            logging.debug(interfaces)
-            for interface in interfaces:
-                iface = interfaces[interface]
-                for addr in iface:
-                    match = re.search(r'^00[\-:]50[\-:]56[\-:]00[\-:]'
-                                      r'([\da-fA-F]+)[\-:]([\da-fA-F]+)$', addr.address)
-                    if match:
-                        server = match.group(1)
-                        machine = match.group(2)
-                        hostname = 'VM{0}-{1}'.format(server, machine)
-        if platform.system() == 'Linux':
-            try:
-                out = subprocess.check_output(["ip", "-o", "route", "get", "1.1.1.1"],
-                                        universal_newlines=True)
-                addr = (out.split(" ")[6]).strip()
-                if addr is not None and len(addr):
-                    hostname += '-' + addr
-            except Exception:
-                pass
-        self.pc_name = hostname if options.name is None else options.name
+        self.pc_name = os_util.pc_name() if options.name is None else options.name
         self.auth_name = options.username
         self.auth_password = options.password if options.password is not None else ''
         self.validate_server_certificate = options.validcertificate


### PR DESCRIPTION
Working on fixing the new logger, I was trying to figure out how the hostname was generated in webpagetest.py and thought maybe we could clean this up and allow me to practice more on PRs). I tried a few different variants but this variant worked on all platforms(Windows, Linux, MacOS) getting the correct local IP address. Other variants worked on windows and Linux but macOS received a localhost IP, instead of a local IP address which is why this pc_name() method was chosen. 
 
As far as Line 108 - 121 in webpagetest.py, I can see its trying to get a mac address but a little unclear if it's important. I tested these lines in (Windows, Linux, MacOS, and a VM of Linux), and received no matches. If it is important maybe we could have a if/elif statement to make it run when needed and not every time.

@pmeenan please review and any feedback is very much appreciated! Thanks



