### PR TITLE
Add support for Wappalyzer dns-based detection

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -52,6 +52,7 @@ class DevtoolsBrowser(object):
         self.script_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'js')
         self.webkit_context = None
         self.total_sleep = 0
+        self.document_domain = None
 
     def shutdown(self):
         """Agent is dying NOW"""
@@ -636,7 +637,10 @@ class DevtoolsBrowser(object):
             with gzip.open(path, GZIP_TEXT, 7) as outfile:
                 outfile.write(json.dumps(user_timing))
         page_data = self.run_js_file('page_data.js')
+        self.document_domain = None
         if page_data is not None:
+            if 'document_hostname' in page_data:
+                self.document_domain = page_data['document_hostname']
             task['page_data'].update(page_data)
 
     def process_command(self, command):
@@ -1058,7 +1062,42 @@ class DevtoolsBrowser(object):
                         if name not in cookies:
                             cookies[name] = []
                         cookies[name].append(cookie['value'])
-                detect_script = self.wappalyzer_script(request_headers, cookies)
+                # Get the relavent DNS records for the origin
+                dns = {}
+                if self.document_domain is not None:
+                    dns_domain = str(self.document_domain)
+                    while dns_domain.find('.') > 0:
+                        logging.debug('Wappalyzer resolving %s', dns_domain)
+                        try:
+                            from dns import resolver
+                            dns_resolver = resolver.Resolver()
+                            dns_resolver.timeout = 1
+                            dns_resolver.lifetime = 1
+                            dns_types = ['CNAME', 'NS', 'MX', 'TXT', 'SOA']
+                            for dns_type in dns_types:
+                                if dns_type not in dns:
+                                    try:
+                                        result = []
+                                        answer = dns_resolver.query(dns_domain, dns_type, raise_on_no_answer=False)
+                                        for a in answer:
+                                            result.append(str(a))
+                                        if len(result):
+                                            dns[dns_type] = result
+                                            logging.debug('Wappalyzer DNS %s for %s: %s', dns_type, dns_domain, json.dumps(result))
+                                    except Exception:
+                                        logging.exception('Error doing wappalyzer DNS %s lookup for %s', dns_type, self.document_domain)
+                        except Exception:
+                            logging.exception('Error doing wappalyzer DNS lookup')
+                        # Walk up a step in case we need to look up a parent-domain record
+                        pos = dns_domain.find('.')
+                        dns_domain = dns_domain[pos + 1:]
+                task['page_data']['origin_dns'] = dns
+                for dns_type in dns_types:
+                    if dns_type not in dns:
+                        dns[dns_type] = []
+                logging.debug('Wappalyzer DNS for %s: %s', self.document_domain, json.dumps(dns))
+                # Generate the wappalyzer script
+                detect_script = self.wappalyzer_script(request_headers, cookies, dns)
                 response = self.devtools.send_command("Runtime.evaluate",
                                                       {'expression': detect_script,
                                                        'awaitPromise': True,
@@ -1087,7 +1126,7 @@ class DevtoolsBrowser(object):
             task['page_data']['wappalyzer_failed'] = 1
         self.profile_end('dtbrowser.wappalyzer_detect')
 
-    def wappalyzer_script(self, response_headers, cookies):
+    def wappalyzer_script(self, response_headers, cookies, dns):
         """Build the wappalyzer script to run in-browser"""
         script = None
         try:
@@ -1132,6 +1171,7 @@ class DevtoolsBrowser(object):
                                         headers[key].append(value)
                         script = script.replace('%WAPPALYZER%', wappalyzer)
                         script = script.replace('%COOKIES%', json.dumps(cookies))
+                        script = script.replace('%DNS%', json.dumps(dns))
                         script = script.replace('%RESPONSE_HEADERS%', json.dumps(headers))
                         script = script.replace('%CATEGORIES%', json.dumps(categories))
                         script = script.replace('%TECHNOLOGIES%', json.dumps(technologies))

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -1064,7 +1064,7 @@ class DevtoolsBrowser(object):
                         cookies[name].append(cookie['value'])
                 # Get the relavent DNS records for the origin
                 dns = {}
-                dns_types = ['cname', 'ns', 'mx', 'txt', 'soa']
+                dns_types = ['cname', 'ns', 'mx', 'txt', 'soa', 'https']
                 if self.document_domain is not None:
                     dns_domain = str(self.document_domain)
                     while dns_domain.find('.') > 0:

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -1064,6 +1064,7 @@ class DevtoolsBrowser(object):
                         cookies[name].append(cookie['value'])
                 # Get the relavent DNS records for the origin
                 dns = {}
+                dns_types = ['cname', 'ns', 'mx', 'txt', 'soa']
                 if self.document_domain is not None:
                     dns_domain = str(self.document_domain)
                     while dns_domain.find('.') > 0:
@@ -1073,12 +1074,11 @@ class DevtoolsBrowser(object):
                             dns_resolver = resolver.Resolver()
                             dns_resolver.timeout = 1
                             dns_resolver.lifetime = 1
-                            dns_types = ['CNAME', 'NS', 'MX', 'TXT', 'SOA']
                             for dns_type in dns_types:
                                 if dns_type not in dns:
                                     try:
                                         result = []
-                                        answer = dns_resolver.query(dns_domain, dns_type, raise_on_no_answer=False)
+                                        answer = dns_resolver.query(dns_domain, dns_type.upper(), raise_on_no_answer=False)
                                         for a in answer:
                                             result.append(str(a))
                                         if len(result):

--- a/internal/support/Wappalyzer/script.js
+++ b/internal/support/Wappalyzer/script.js
@@ -4,6 +4,7 @@
   const wappalyzer_categories = %CATEGORIES%;
   const cookies = %COOKIES%;
   const responseHeaders = %RESPONSE_HEADERS%;
+  const dns = %DNS%;
   Wappalyzer.setTechnologies(wappalyzer_technologies);
   Wappalyzer.setCategories(wappalyzer_categories);
 
@@ -51,7 +52,8 @@
       headers: responseHeaders,
       meta: meta,
       cookies: cookies,
-      scriptSrc: scripts
+      scriptSrc: scripts,
+      dns: dns
     });
     let dom = getDom(Wappalyzer.technologies);
     detections = detections.concat(analyzeDom(dom, Wappalyzer.technologies));
@@ -76,7 +78,8 @@
           headers: responseHeaders,
           meta: meta,
           cookies: cookies,
-          scriptSrc: scripts
+          scriptSrc: scripts,
+          dns: dns
         }, requires_tech));
       dom = getDom(requires_tech);
       detections = detections.concat(analyzeDom(dom, requires_tech));
@@ -137,8 +140,8 @@
     let wptResult = JSON.stringify({
       categories: categories,
       apps: apps,
-      technologies: detected,
-      resolved: resolved
+      //technologies: detected,
+      //resolved: resolved
     });
     return wptResult;
   }

--- a/internal/support/Wappalyzer/script.js
+++ b/internal/support/Wappalyzer/script.js
@@ -140,8 +140,8 @@
     let wptResult = JSON.stringify({
       categories: categories,
       apps: apps,
-      //technologies: detected,
-      //resolved: resolved
+      technologies: detected,
+      resolved: resolved
     });
     return wptResult;
   }


### PR DESCRIPTION
This adds support for the DNS-based wappalyzer detections (hosting, CDN's and email providers mostly so far).

The DNS record lookups are done at the end of the test before running wappalyzer but it is in parallel with the other optimization checks and with a short timeout so it doesn't extend the actual test time.

It also adds the raw DNS records for the origin to the page data output, including the HTTPS DNS record which could become more interesting soon when Chrome adds support for using it to detect HTTP/3 support.