### PR TITLE
Use the streaming netlog as the primary source for response bodies

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -63,6 +63,9 @@ class DevTools(object):
         self.trace_file = None
         self.trace_enabled = False
         self.requests = {}
+        self.netlog_requests = {}
+        self.netlog_urls = {}
+        self.netlog_lock = threading.Lock()
         self.request_count = 0
         self.response_bodies = {}
         self.body_fail_count = 0
@@ -667,7 +670,26 @@ class DevTools(object):
         """Retrieve and store the given response body (if necessary)"""
         if request_id not in self.response_bodies and self.body_fail_count < 3 and not self.is_ios and not self.must_exit:
             request = self.get_request(request_id, True)
-            if request is not None and 'status' in request and request['status'] == 200 and \
+            # See if we have a netlog-based response body
+            found = False
+            if request is not None and 'url' in request:
+                try:
+                    path = os.path.join(self.task['dir'], 'netlog_bodies')
+                    with self.netlog_lock:
+                        if request['url'] in self.netlog_urls:
+                            for netlog_id in self.netlog_urls[request['url']]:
+                                if netlog_id in self.netlog_requests and 'body_claimed' not in self.netlog_requests[netlog_id]:
+                                    body_file_path = os.path.join(path, netlog_id)
+                                    if os.path.exists(body_file_path):
+                                        self.netlog_requests[netlog_id]['body_claimed'] = True
+                                        found = True
+                                        logging.debug('Matched netlog response body %s for %s', netlog_id, request['url'])
+                                        self.process_response_body(request_id, None, body_file_path)
+                    if not found and len(self.netlog_requests):
+                        logging.debug('Unable to match netlog response body for %s', request['url'])
+                except Exception:
+                    logging.exception('Error matching netlog response body')
+            if not found and request is not None and 'status' in request and request['status'] == 200 and \
                     'response_headers' in request and 'url' in request and request['url'].startswith('http'):
                 content_length = self.get_header_value(request['response_headers'], 'Content-Length')
                 if content_length is not None:
@@ -703,64 +725,83 @@ class DevTools(object):
                         if wait:
                             self.process_response_body(request_id, response)
 
-    def process_response_body(self, request_id, response):
-        request = self.get_request(request_id, True)
-        path = os.path.join(self.task['dir'], 'bodies')
-        if not os.path.isdir(path):
-            os.makedirs(path)
-        body_file_path = os.path.join(path, request_id)
-        if not os.path.exists(body_file_path):
+    def process_response_body(self, request_id, response, netlog_body_file=None):
+        try:
+            request = self.get_request(request_id, True)
+            path = os.path.join(self.task['dir'], 'bodies')
+            if not os.path.isdir(path):
+                os.makedirs(path)
+            body_file_path = os.path.join(path, request_id)
             is_text = False
-            if request is not None and 'status' in request and request['status'] == 200 and 'response_headers' in request:
-                content_type = self.get_header_value(request['response_headers'], 'Content-Type')
-                if content_type is not None:
-                    content_type = content_type.lower()
-                    if content_type.startswith('text/') or \
-                            content_type.find('javascript') >= 0 or \
-                            content_type.find('json') >= 0 or \
-                            content_type.find('/svg+xml'):
-                        is_text = True
-            if response is None:
-                self.body_fail_count += 1
-                logging.warning('No response to body request for request %s',
-                                request_id)
-            elif 'result' not in response or \
-                    'body' not in response['result']:
-                self.body_fail_count = 0
-                logging.warning('Missing response body for request %s',
-                                request_id)
-            elif len(response['result']['body']):
+            body = None
+            if netlog_body_file is not None:
                 try:
-                    self.body_fail_count = 0
-                    # Write the raw body to a file (all bodies)
-                    if 'base64Encoded' in response['result'] and \
-                            response['result']['base64Encoded']:
-                        body = base64.b64decode(response['result']['body'])
-                        is_text = False
-                    else:
-                        body = response['result']['body'].encode('utf-8')
+                    with open(netlog_body_file, 'r', encoding='utf-8') as f:
+                        body = f.read()
+                        body = body.encode('utf-8')
                         is_text = True
-                    if 'request_headers' in request and 'Sec-Fetch-Dest' in request['request_headers']:
-                        if request['request_headers']['Sec-Fetch-Dest'] in ['audio', 'audioworklet', 'font', 'image', 'object', 'track', 'video']:
-                            is_text = False
-                    # Add text bodies to the zip archive
-                    store_body = self.all_bodies
-                    if self.html_body and request_id == self.main_request:
-                        store_body = True
-                    if store_body and self.bodies_zip_file is not None and is_text:
-                        self.body_index += 1
-                        name = '{0:03d}-{1}-body.txt'.format(self.body_index, request_id)
-                        self.bodies_zip_file.writestr(name, body)
-                        logging.debug('%s: Stored body in zip', request_id)
-                    logging.debug('%s: Body length: %d', request_id, len(body))
-                    self.response_bodies[request_id] = body
-                    with open(body_file_path, 'wb') as body_file:
-                        body_file.write(body)
                 except Exception:
-                    logging.exception('Exception retrieving body')
-            else:
-                self.body_fail_count = 0
-                self.response_bodies[request_id] = response['result']['body']
+                    pass
+                if body is None:
+                    with open(netlog_body_file, 'rb') as f:
+                        body = f.read()
+            elif not os.path.exists(body_file_path):
+                is_text = False
+                if request is not None and 'status' in request and request['status'] == 200 and 'response_headers' in request:
+                    content_type = self.get_header_value(request['response_headers'], 'Content-Type')
+                    if content_type is not None:
+                        content_type = content_type.lower()
+                        if content_type.startswith('text/') or \
+                                content_type.find('javascript') >= 0 or \
+                                content_type.find('json') >= 0 or \
+                                content_type.find('/svg+xml'):
+                            is_text = True
+                if response is None:
+                    self.body_fail_count += 1
+                    logging.warning('No response to body request for request %s',
+                                    request_id)
+                elif 'result' not in response or \
+                        'body' not in response['result']:
+                    self.body_fail_count = 0
+                    logging.warning('Missing response body for request %s',
+                                    request_id)
+                elif len(response['result']['body']):
+                    try:
+                        self.body_fail_count = 0
+                        # Write the raw body to a file (all bodies)
+                        if 'base64Encoded' in response['result'] and \
+                                response['result']['base64Encoded']:
+                            body = base64.b64decode(response['result']['body'])
+                            is_text = False
+                        else:
+                            body = response['result']['body'].encode('utf-8')
+                            is_text = True
+                    except Exception:
+                        logging.exception('Exception retrieving body')
+                else:
+                    self.body_fail_count = 0
+                    self.response_bodies[request_id] = response['result']['body']
+            # Store the actual body for processing
+            if body is not None and not os.path.exists(body_file_path):
+                if 'request_headers' in request:
+                    fetch_dest = self.get_header_value(request['request_headers'], 'Sec-Fetch-Dest')
+                    if fetch_dest is not None and fetch_dest in ['audio', 'audioworklet', 'font', 'image', 'object', 'track', 'video']:
+                        is_text = False
+                # Add text bodies to the zip archive
+                store_body = self.all_bodies
+                if self.html_body and request_id == self.main_request:
+                    store_body = True
+                if store_body and self.bodies_zip_file is not None and is_text:
+                    self.body_index += 1
+                    name = '{0:03d}-{1}-body.txt'.format(self.body_index, request_id)
+                    self.bodies_zip_file.writestr(name, body)
+                    logging.debug('%s: Stored body in zip', request_id)
+                logging.debug('%s: Body length: %d', request_id, len(body))
+                self.response_bodies[request_id] = body
+                with open(body_file_path, 'wb') as body_file:
+                    body_file.write(body)
+        except Exception:
+            logging.exception('Error processing response body')
 
     def get_response_bodies(self):
         """Retrieve all of the response bodies for the requests that we know about"""
@@ -837,6 +878,20 @@ class DevTools(object):
                 request['transfer_size'] = transfer_size
         return request
 
+    def extract_headers(self, raw_headers):
+        """Convert flat headers into a keyed dictionary"""
+        headers = {}
+        for header in raw_headers:
+            key_len = header.find(':', 1)
+            if key_len >= 0:
+                key = header[:key_len].strip(' :')
+                value = header[key_len + 1:].strip()
+                if key in headers:
+                    headers[key] += ',' + value
+                else:
+                    headers[key] = value
+        return headers
+
     def get_requests(self, include_bodies):
         """Get a dictionary of all of the requests and the details (headers, body file)"""
         requests = None
@@ -847,6 +902,38 @@ class DevTools(object):
                     if requests is None:
                         requests = {}
                     requests[request_id] = request
+        # Patch-in any netlog requests that were not seen through dev tools
+        # This is only used for optimization checks and custom metrics, not the
+        # actual waterfall.
+        with self.netlog_lock:
+            try:
+                path = os.path.join(self.task['dir'], 'netlog_bodies')
+                for netlog_id in self.netlog_requests:
+                    netlog_request = self.netlog_requests[netlog_id]
+                    if 'url' in netlog_request:
+                        url = netlog_request['url']
+                        found = False
+                        for request_id in requests:
+                            request = requests[request_id]
+                            if 'url' in request and request['url'] == url:
+                                found = True
+                        if not found:
+                            request = {'id': netlog_id, 'url': url}
+                            if 'request_headers' in netlog_request:
+                                request['request_headers'] = self.extract_headers(netlog_request['request_headers'])
+                            if 'response_headers' in netlog_request:
+                                request['response_headers'] = self.extract_headers(netlog_request['response_headers'])
+                            body_file_path = os.path.join(path, netlog_id)
+                            if os.path.exists(body_file_path):
+                                request['body'] = body_file_path
+                                body = None
+                                with open(body_file_path, 'rb') as f:
+                                    body = f.read()
+                                if body is not None and len(body):
+                                    request['response_body'] = body
+                            requests[netlog_id] = request
+            except Exception:
+                logging.exception('Error adding netlog requests')
         return requests
 
     def flush_pending_messages(self):
@@ -1713,6 +1800,59 @@ class DevTools(object):
                     self.task['profile_data'][event_name]['e'] = round(monotonic() - self.task['profile_data']['start'], 3)
                     self.task['profile_data'][event_name]['d'] = round(self.task['profile_data'][event_name]['e'] - self.task['profile_data'][event_name]['s'], 3)
 
+    def on_netlog_request_created(self, request_id, request_info):
+        """Callbacks from streamed netlog processing (these will come in on a background thread)"""
+        try:
+            with self.netlog_lock:
+                if request_id not in self.netlog_requests:
+                    self.netlog_requests[request_id] = request_info
+                if 'url' in request_info:
+                    url = request_info['url']
+                    self.netlog_requests[request_id]['url'] = url
+                    if url not in self.netlog_urls:
+                        self.netlog_urls[url] = []
+                    if request_id not in self.netlog_urls[url]:
+                        self.netlog_urls[url].append(request_id)
+            logging.debug("Netlog request %s created: %s", request_id, json.dumps(request_info))
+        except Exception:
+            logging.exception('Error handling on_netlog_request_created')
+
+    def on_netlog_request_headers_sent(self, request_id, request_headers):
+        """Callbacks from streamed netlog processing (these will come in on a background thread)"""
+        try:
+            with self.netlog_lock:
+                if request_id not in self.netlog_requests:
+                    self.netlog_requests[request_id] = {}
+                self.netlog_requests[request_id]['request_headers'] = request_headers
+            logging.debug("Netlog request headers for %s: %s", request_id, json.dumps(request_headers))
+        except Exception:
+            logging.exception('Error handling on_netlog_request_headers_sent')
+
+    def on_netlog_response_headers_received(self, request_id, response_headers):
+        """Callbacks from streamed netlog processing (these will come in on a background thread)"""
+        try:
+            with self.netlog_lock:
+                if request_id not in self.netlog_requests:
+                    self.netlog_requests[request_id] = {}
+                self.netlog_requests[request_id]['response_headers'] = response_headers
+            logging.debug("Netlog response headers for %s: %s", request_id, json.dumps(response_headers))
+        except Exception:
+            logging.exception('Error handling on_netlog_response_headers_received')
+
+    def on_netlog_response_bytes_received(self, request_id, filtered_bytes):
+        """Callbacks from streamed netlog processing (these will come in on a background thread)"""
+        try:
+            if filtered_bytes is not None and len(filtered_bytes):
+                with self.netlog_lock:
+                    path = os.path.join(self.task['dir'], 'netlog_bodies')
+                    if not os.path.isdir(path):
+                        os.makedirs(path)
+                    body_file_path = os.path.join(path, request_id)
+                    with open(body_file_path, 'a+b') as body_file:
+                        body_file.write(filtered_bytes)
+            logging.debug("Netlog response bytes for %s: %d bytes", request_id, len(filtered_bytes))
+        except Exception:
+            logging.exception('Error handling on_netlog_response_bytes_received')
 
 class DevToolsClient(WebSocketClient):
     """DevTools WebSocket client"""

--- a/internal/support/devtools_parser.py
+++ b/internal/support/devtools_parser.py
@@ -877,7 +877,8 @@ class DevToolsParser(object):
                    'tls_next_proto': 'tls_next_proto',
                    'tls_cipher_suite': 'tls_cipher_suite',
                    'uncompressed_bytes_in': 'objectSizeUncompressed',
-                   'early_hint_headers': 'early_hint_headers'}
+                   'early_hint_headers': 'early_hint_headers',
+                   'netlog_id': 'netlog_id'}
         if self.netlog_requests_file is not None and os.path.isfile(self.netlog_requests_file):
             _, ext = os.path.splitext(self.netlog_requests_file)
             if ext.lower() == '.gz':

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -1262,6 +1262,7 @@ class WebPageTest(object):
         try:
             path_base = os.path.join(task['dir'], task['prefix'])
             path = os.path.join(task['dir'], 'bodies')
+            netlog_path = os.path.join(task['dir'], 'netlog_bodies')
             requests = []
             devtools_file = os.path.join(task['dir'], task['prefix'] + '_devtools_requests.json.gz')
             with gzip.open(devtools_file, GZIP_READ_TEXT) as f_in:
@@ -1311,6 +1312,9 @@ class WebPageTest(object):
                             if body_id not in bodies:
                                 count += 1
                                 body_file_path = os.path.join(path, str(body_id))
+                                netlog_file_path = None
+                                if 'netlog_id' in request:
+                                    netlog_file_path = os.path.join(netlog_path, str(request['netlog_id']))
                                 headers = None
                                 if 'headers' in request and 'request' in request['headers']:
                                     headers = request['headers']['request']
@@ -1318,7 +1322,9 @@ class WebPageTest(object):
                                         'file': body_file_path,
                                         'id': body_id,
                                         'headers': headers}
-                                if os.path.isfile(body_file_path):
+                                if os.path.isfile(body_file_path) or os.path.isfile(netlog_file_path):
+                                    if netlog_file_path is not None and os.path.isfile(netlog_file_path):
+                                        task['netlog_file'] = netlog_file_path
                                     self.fetch_result_queue.put(task)
                                 else:
                                     self.fetch_queue.put(task)
@@ -1348,18 +1354,18 @@ class WebPageTest(object):
                             if thread_count == 0:
                                 break
                         else:
-                            if os.path.isfile(task['file']):
-                                # check to see if it is text or utf-8 data
+                            file_path = task['netlog_file'] if 'netlog_file' in task else task['file']
+                            if os.path.isfile(file_path):
+                                # Only append if the data can be read as utf-8
                                 try:
-                                    data = ''
-                                    with open(task['file'], 'r') as f_in:
-                                        data = f_in.read()
-                                    json.loads('"' + data.replace('"', '\\"') + '"')
+                                    with open(file_path, 'r', encoding='utf-8') as f_in:
+                                        f_in.read()
                                     body_index += 1
                                     file_name = '{0:03d}-{1}-body.txt'.format(body_index, task['id'])
-                                    bodies.append({'name': file_name, 'file': task['file']})
+                                    bodies.append({'name': file_name, 'file': file_path})
+                                    logging.debug('Added response body for %s', task['url'])
                                 except Exception:
-                                    logging.exception('Error appending bodies')
+                                    logging.exception('Non-text body for %s', task['url'])
                             self.fetch_result_queue.task_done()
                 except Exception:
                     pass


### PR DESCRIPTION
This turns on response body byte capturing when the streaming netlogs are active and uses that as the primary source for response bodies (falling back to the legacy dev tools method if a body isn't available from the netlog). It also reduces the overhead since it is using memory-mapped pipes for the file I/O from netlog (on a background thread) instead of bouncing through the dev tools protocol.

This applies both to the response bodies captured all of the time for optimization checks as well as the response bodies that are stored when explicitly requested.

We were seeing some edge cases where service worker scripts could not retrieve the response bodies through dev tools and this completely resolves that issue.