### PR TITLE
Improved the logic for finding the base page request

### DIFF
--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -1340,7 +1340,9 @@ class Firefox(DesktopBrowser):
                             (request['responseCode'] == 200 or request['responseCode'] == 304) and \
                             ('contentType' not in request or
                             (request['contentType'] != 'application/ocsp-response' and
-                            request['contentType'] != 'application/pkix-crl')):
+                             request['contentType'] != 'application/pkix-crl' and 
+                             request['contentType'] != 'application/pkix-cert' and
+                             request['contentType'] != 'application/ca-cert')):
                         main_request = request['id']
                         request['is_base_page'] = True
                         page['final_base_page_request'] = index


### PR DESCRIPTION
We were seeing a small number of pages in the HTTP Archive where the OCSP check was being flagged as the main document request.  This improves the logic pretty significantly by first preferring the "sec-fetch-dest: document" request header and then falling back to the content-type filtering (which now includes the mime type we were missing previously).