### PR TITLE
Add reporting of the uncompressed size in the chunk timings

### DIFF
--- a/internal/support/netlog.py
+++ b/internal/support/netlog.py
@@ -916,6 +916,8 @@ class Netlog():
             if 'has_raw_bytes' not in entry or not entry['has_raw_bytes']:
                 entry['bytes_in'] += params['byte_count']
                 entry['chunks'].append({'ts': event['time'], 'bytes': params['byte_count']})
+            elif entry['chunks']:
+                entry['chunks'][-1]['filtered'] = params['byte_count']
             if 'bytes' in params and self.on_response_bytes_received is not None:
                 try:
                     raw_bytes = base64.b64decode(params['bytes'])

--- a/internal/support/netlog.py
+++ b/internal/support/netlog.py
@@ -917,7 +917,7 @@ class Netlog():
                 entry['bytes_in'] += params['byte_count']
                 entry['chunks'].append({'ts': event['time'], 'bytes': params['byte_count']})
             elif entry['chunks']:
-                entry['chunks'][-1]['filtered'] = params['byte_count']
+                entry['chunks'][-1]['inflated'] = params['byte_count']
             if 'bytes' in params and self.on_response_bytes_received is not None:
                 try:
                     raw_bytes = base64.b64decode(params['bytes'])


### PR DESCRIPTION
This adds a "filtered" size entry to the chunk timings that carries the decompressed size of resources that are content-encoded (gzip, brotli). 

```json
    "chunks": [
        {
            "ts": 444,
            "bytes": 1387,
            "filtered": 2985
        },
        {
            "ts": 446,
            "bytes": 1396,
            "filtered": 3677
        },
        {
            "ts": 466,
            "bytes": 1396,
            "filtered": 3888
        },
```

This will make it possible to map individual chunks of HTML back to when they were flushed.

Some possible uses come to mind:
* Highlight the time in the waterfall when the LCP image element was delivered on the wire.
* Provide a UI that shows the raw HTML response body and match selection or cursor position to where in the waterfall entry that chunk of HTML was delivered.