### PR TITLE
Selectively extract element information for LCP and CLS events

### DIFF
--- a/internal/support/chrome/inject.js
+++ b/internal/support/chrome/inject.js
@@ -1,64 +1,65 @@
-var WptAgentFlatten = function(object) {
-    let contents = {}
-    for (const key in object) {
-        if (key == 'children') {
-            continue;
-        }
-        if (typeof(object[key]) === 'object') {
-            if (Array.isArray(object[key])) {
-                let values = [];
-                for (const e of object[key]) {
-                    if (typeof(e) === 'object') {
-                        values.push(WptAgentFlatten(e));
-                    } else if (typeof(e) !== 'function') {
-                        values.push(e);
-                    }
-                }
-                contents[key] = values;
-            } else if (key == 'element' || key == 'node' || key == 'currentRect' || key == 'previousRect') {
-                contents[key] = WptAgentFlatten(object[key]);
-                if (typeof object[key]['getBoundingClientRect'] === 'function') {
-                    contents[key]['boundingRect'] =  object[key].getBoundingClientRect();
-                }
-                if (key == 'element') {
-                    try {
-                        let style = window.getComputedStyle(object[key]);
-                        if (style.backgroundImage && style.backgroundImage != 'none') {
-                            contents[key]['background-image'] = style.backgroundImage;
-                        }
-                    } catch (err) {
-                    }
-                }
-            }
-        } else if (typeof(object[key]) === 'string') {
-            if (object[key].length > 0 &&
-                    key != 'innerText' &&
-                    key != 'outerText' &&
-                    key != 'innerHTML' &&
-                    key != 'textContent' &&
-                    key != 'baseURI' &&
-                    key != 'namespaceURI') {
-                contents[key] = object[key];
-            }
-        } else if (typeof(object[key]) !== 'function') {
-            if (!/^[A-Z_]+$/.test(key)) {
-                contents[key] = object[key];
-            }
-        }
-    }
-    return contents;
-}
-
-var WptAgentReportPerformanceTiming = function(entryList){
+const wptagent_lcp_observer = new PerformanceObserver((entryList) => {
     for (const entry of entryList.getEntries()) {
-        console.debug('wptagent_message:' + JSON.stringify({'name': 'perfentry', 'data': WptAgentFlatten(entry)}));
+      try {
+          let event = {
+              name: entry.name,
+              entryType: entry.entryType,
+              startTime: entry['startTime'],
+              size: entry['size'],
+              url: entry['url'],
+              id: entry['id'],
+              loadTime: entry['loadTime'],
+              renderTime: entry['renderTime']
+          };
+          if (entry['element']) {
+              event['element'] = {
+                  nodeName: entry.element['nodeName'],
+                  boundingRect: entry.element.getBoundingClientRect(),
+                  outerHTML: entry.element.outerHTML
+              }
+              if (entry.element['src']) {
+                  event.element['src'] = entry.element.src
+              }
+              if (entry.element['currentSrc']) {
+                  event.element['currentSrc'] = entry.element.currentSrc
+              }
+              try {
+                  let style = window.getComputedStyle(object[key]);
+                  if (style.backgroundImage && style.backgroundImage != 'none') {
+                      contents[key]['background-image'] = style.backgroundImage;
+                  }
+              } catch (err) {
+              }
+          }
+          console.debug('wptagent_message:' + JSON.stringify({'name': 'perfentry', 'data': event}));
+        } catch (err) {
+        }
     }
-}
+}).observe({type: 'largest-contentful-paint', buffered: true});
 
-var wptagent_perf_observer = new PerformanceObserver((entryList) => {
-    WptAgentReportPerformanceTiming(entryList);
-});
-wptagent_perf_observer.observe({type: 'largest-contentful-paint', buffered: true});
-wptagent_perf_observer.observe({type: 'layout-shift', buffered: true});
-wptagent_perf_observer.observe({type: 'paint', buffered: true});
-wptagent_perf_observer.observe({type: 'element', buffered: true});
+const wptagent_cls_observer = new PerformanceObserver((entryList) => {
+    for (const entry of entryList.getEntries()) {
+        try {
+            let event = {
+                name: entry.name,
+                entryType: entry.entryType,
+                startTime: entry['startTime'],
+                value: entry['value'],
+                hadRecentInput: entry['hadRecentInput'],
+                lastInputTime: entry['lastInputTime']
+            };
+            if (entry['sources']) {
+                event['sources'] = [];
+                for (const source of entry.sources) {
+                    let src = {
+                        previousRect: source.previousRect,
+                        currentRect: source.currentRect
+                    }
+                    event.sources.push(src);
+                }
+            }
+            console.debug('wptagent_message:' + JSON.stringify({'name': 'perfentry', 'data': event}));
+        } catch (err) {
+        }
+    }
+}).observe({type: 'layout-shift', buffered: true});

--- a/internal/support/chrome/inject.js
+++ b/internal/support/chrome/inject.js
@@ -1,4 +1,4 @@
-const wptagent_lcp_observer = new PerformanceObserver((entryList) => {
+new PerformanceObserver((entryList) => {
     for (const entry of entryList.getEntries()) {
       try {
           let event = {
@@ -9,19 +9,19 @@ const wptagent_lcp_observer = new PerformanceObserver((entryList) => {
               url: entry['url'],
               id: entry['id'],
               loadTime: entry['loadTime'],
-              renderTime: entry['renderTime']
+              renderTime: entry['renderTime'],
           };
           if (entry['element']) {
               event['element'] = {
                   nodeName: entry.element['nodeName'],
                   boundingRect: entry.element.getBoundingClientRect(),
-                  outerHTML: entry.element.outerHTML
+                  outerHTML: entry.element.outerHTML,
               }
               if (entry.element['src']) {
-                  event.element['src'] = entry.element.src
+                  event.element['src'] = entry.element.src;
               }
               if (entry.element['currentSrc']) {
-                  event.element['currentSrc'] = entry.element.currentSrc
+                  event.element['currentSrc'] = entry.element.currentSrc;
               }
               try {
                   let style = window.getComputedStyle(object[key]);
@@ -37,7 +37,7 @@ const wptagent_lcp_observer = new PerformanceObserver((entryList) => {
     }
 }).observe({type: 'largest-contentful-paint', buffered: true});
 
-const wptagent_cls_observer = new PerformanceObserver((entryList) => {
+new PerformanceObserver((entryList) => {
     for (const entry of entryList.getEntries()) {
         try {
             let event = {
@@ -46,14 +46,14 @@ const wptagent_cls_observer = new PerformanceObserver((entryList) => {
                 startTime: entry['startTime'],
                 value: entry['value'],
                 hadRecentInput: entry['hadRecentInput'],
-                lastInputTime: entry['lastInputTime']
+                lastInputTime: entry['lastInputTime'],
             };
             if (entry['sources']) {
                 event['sources'] = [];
                 for (const source of entry.sources) {
                     let src = {
                         previousRect: source.previousRect,
-                        currentRect: source.currentRect
+                        currentRect: source.currentRect,
                     }
                     event.sources.push(src);
                 }


### PR DESCRIPTION
Fix https://github.com/WPO-Foundation/wptagent/issues/564

Avoids iterating over every property of the elements and tripping feature usage flags.

This should also reduce the overhead of the injected script slightly and extracts everything the UI needs to do the LCP and CLS analysis.

The element timing and paint timing observers were not being used yet so leave those out until they are actually added to the output.