### PR TITLE
Add SVCB records to the document dns report

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -1064,7 +1064,7 @@ class DevtoolsBrowser(object):
                         cookies[name].append(cookie['value'])
                 # Get the relavent DNS records for the origin
                 dns = {}
-                dns_types = ['cname', 'ns', 'mx', 'txt', 'soa', 'https']
+                dns_types = ['cname', 'ns', 'mx', 'txt', 'soa', 'https', 'svcb']
                 if self.document_domain is not None:
                     dns_domain = str(self.document_domain)
                     while dns_domain.find('.') > 0:


### PR DESCRIPTION
Example result:

```json
"origin_dns": {
   "https": [
       "1 . alpn=\"h3,h3-29,h2\" ipv4hint=\"104.21.21.209,172.67.200.88\" ipv6hint=\"2606:4700:3030::ac43:c858,2606:4700:3032::6815:15d1\""
   ],
   "svcb": [
       "1 www.dthhelp.net. alpn=\"h3,h2\" ipv4hint=\"104.36.110.175\""
   ],
   "ns": [
       "zoe.ns.cloudflare.com.",
       "rob.ns.cloudflare.com."
   ],
   "mx": [
       "0 mail.dthhelp.net."
   ],
   "txt": [
       "\"Sendinblue-code:7c982d0160aa3cbd7ea35c42277f9816\"",
       "\"v=spf1 include:spf.sendinblue.com mx ~all\""
   ],
   "soa": [
       "rob.ns.cloudflare.com. dns.cloudflare.com. 2288132220 10000 2400 604800 3600"
   ],
   "cname": []
},
```