### PR TITLE
--alertsize added to give more details on oversized files in web testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ wptagent.alive
 vpn-reverse-tether/amd64/tether.sh
 vpn.sh
 .DS_Store
+/logging

--- a/internal/base_browser.py
+++ b/internal/base_browser.py
@@ -21,6 +21,10 @@ class BaseBrowser(object):
     def execute_js(self, script):
         """Stub to be overridden"""
         return None
+    
+    def alert_size(self,_alert_config, _task_dir, _prefix):
+        '''File alerting function to be overridden by browser class'''
+        return None
 
     def profile_start(self, event_name):
         if self.task is not None and 'profile_data' in self.task:

--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -277,6 +277,10 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
         if self.connected:
             DevtoolsBrowser.run_task(self, task)
 
+    def alert_size(self, _alert_config, _task_dir, _prefix):
+        '''Checks the agents file size and alert on certain percentage over avg byte size'''               
+        self.alert_desktop_results(_alert_config, 'Chrome', _task_dir, _prefix)
+
     def execute_js(self, script):
         """Run javascipt"""
         return DevtoolsBrowser.execute_js(self, script)

--- a/internal/config/alert_config.ini
+++ b/internal/config/alert_config.ini
@@ -1,0 +1,41 @@
+[DEFAULT]
+alert_percent = 200
+alert_path = logging
+alert_file = alerts.json
+alert_file_max_byte_size = 50000000
+
+#Prefix get added to each file name according to the test_run number
+[Chrome]
+active = True
+# You can add a custom alert percent for each browser
+#alert_percent = 100 
+_progress.csv.gz = 898
+_trace.json.gz = 107997
+_user_timing.json.gz = 3726
+_timeline_cpu.json.gz = 8192
+_script_timing.json.gz = 5187
+_interactive.json.gz = 165
+_long_tasks.json.gz = 164
+_feature_usage.json.gz = 4476
+_v8stats.json.gz = 1218
+_screen.jpg = 4340
+_console_log.json.gz = 47
+_timed_events.json.gz = 148
+_visual_progress.json.gz = 119
+_devtools_requests.json.gz = 51174
+_page_data.json.gz = 9563
+.0.histograms.json.gz = 4870
+
+[Firefox]
+active = True
+# You can add a custom alert percent for each browser
+#alert_percent = 0 
+_devtools_requests.json.gz = 17993
+_interactive.json.gz = 146
+_long_tasks.json.gz = 141
+_page_data.json.gz = 7501
+_progress.csv.gz = 600
+_timed_events.json.gz = 137
+_visual_progress.json.gz = 119
+.0.histograms.json.gz = 5776
+

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -404,6 +404,11 @@ class Firefox(DesktopBrowser):
                 logging.exception('Marionette exception navigating to about:blank after the test')
             self.task = None
 
+    def alert_size(self, _alert_config, _task_dir, _prefix):
+        '''Checks the agents file size and alert on certain percentage over avg byte size'''             
+        self.alert_desktop_results(_alert_config, 'Firefox', _task_dir, _prefix)
+
+
     def wait_for_extension(self):
         """Wait for the extension to send the started message"""
         if self.job['message_server'] is not None:

--- a/wptagent.py
+++ b/wptagent.py
@@ -83,6 +83,11 @@ class WPTAgent(object):
                                 self.image_magick['mogrify'] = mogrify
                                 break
 
+        if 'alertsize' in options and options.alertsize == True:
+            import configparser
+            self.alert_config = configparser.ConfigParser()
+            self.alert_config.read('internal/config/alert_config.ini')
+
     def run_testing(self):
         """Main testing flow"""
         if (sys.version_info >= (3, 0)):
@@ -327,6 +332,9 @@ class WPTAgent(object):
                             logging.exception('Error compressing lighthouse log')
                 else:
                     self.browser.run_task(self.task)
+                    # Alerts on large files in the results folder
+                    if 'alertsize' in self.options and self.options.alertsize:
+                        self.browser.alert_size(self.alert_config,self.task['dir'], self.task['task_prefix'])
             except Exception as err:
                 msg = ''
                 if err is not None and err.__str__() is not None:
@@ -1175,7 +1183,7 @@ def main():
     parser.add_argument('--testout', help="Output format (CLI). Valid options are id, url or json")
     parser.add_argument('--testruns', type=int, default=1, help="Number of test runs (CLI - defaults to 1).")
     parser.add_argument('--testrv', action='store_true', default=False, help="Include Repeat View tests (CLI - defaults to False).")
-
+    parser.add_argument('--alertsize', action='store_true', default=False, help="Alerts on large result file size(logging/alerts.log)")
     options, _ = parser.parse_known_args()
 
     # Make sure we are running python 2.7.11 or newer (required for Windows 8.1)


### PR DESCRIPTION
@tkadlec Created the custom alert on task file sizes enabled through running args of --alertsize.  I currently need more details but here is what I have so far. 

- Followed the inheritance of the wptagent.
- Three desktop browsers implemented so far (chrome, firefox, edge-chromium) and works with --testruns X. 
- Created "internal/config/alert_config.ini" to adjust byte sizes allowed and percent difference to alert on. Example alerts.json 
 output here ([alerts.zip](https://github.com/WPO-Foundation/wptagent/files/9601854/alerts.zip))
- Currently the config is set with file sizes of the average of 10 runs of www.google.com


Here is some screen grabs as well.

![alerts json](https://user-images.githubusercontent.com/33207323/191103549-628c791f-6372-435f-90a5-8276aab3112b.png)
![running_args](https://user-images.githubusercontent.com/33207323/191103565-b330c731-b6b9-458c-a9b5-de66054a66c6.png)

