### PR TITLE
Add support for reporting titleTime for Chrome

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -422,6 +422,9 @@ class DevTools(object):
             # Add the required trace events
             if "rail" not in trace_config["includedCategories"]:
                 trace_config["includedCategories"].append("rail")
+            if "content" not in trace_config["includedCategories"]:
+                trace_config["includedCategories"].append("content")
+                self.job['discard_trace_content'] = True
             if "loading" not in trace_config["includedCategories"]:
                 trace_config["includedCategories"].append("loading")
             if "blink.user_timing" not in trace_config["includedCategories"]:
@@ -1982,6 +1985,7 @@ class DevToolsClient(WebSocketClient):
                 self.trace_parser.WriteLongTasks(self.path_base + '_long_tasks.json.gz')
                 self.trace_parser.WriteTimelineRequests(self.path_base + '_timeline_requests.json.gz')
             self.trace_parser.WriteFeatureUsage(self.path_base + '_feature_usage.json.gz')
+            self.trace_parser.WritePageData(self.path_base + '_trace_page_data.json.gz')
             if not job.get('streaming_netlog'):
                 self.trace_parser.WriteNetlog(self.path_base + '_netlog_requests.json.gz')
             self.trace_parser.WriteV8Stats(self.path_base + '_v8stats.json.gz')
@@ -2036,6 +2040,8 @@ class DevToolsClient(WebSocketClient):
                         self.trace_event_counts[trace_event['cat']] = 0
                     self.trace_event_counts[trace_event['cat']] += 1
                     if not self.job['keep_netlog'] and trace_event['cat'] == 'netlog':
+                        keep_event = False
+                    if 'discard_trace_content' in self.job and self.job['discard_trace_content'] and trace_event['cat'] == 'content':
                         keep_event = False
                     if process_event and self.trace_parser is not None:
                         self.trace_parser.ProcessTraceEvent(trace_event)

--- a/internal/process_test.py
+++ b/internal/process_test.py
@@ -71,6 +71,7 @@ class ProcessTest(object):
         self.add_summary_metrics()
         self.merge_crux_data()
         self.merge_lighthouse_data()
+        self.merge_trace_page_data()
 
         # Mark the data as having been processed so the server can know not to re-process it
         page_data['edge-processed'] = True
@@ -561,6 +562,24 @@ class ProcessTest(object):
                         self.delete.append(metrics_file)
         except Exception:
             logging.exception('Error merging blink features')
+
+    def merge_trace_page_data(self):
+        """Merge any page data that was extracted from the trace events"""
+        try:
+            page_data = self.data['pageData']
+            metrics_file = os.path.join(self.task['dir'], self.prefix + '_trace_page_data.json.gz')
+            if os.path.isfile(metrics_file):
+                with gzip.open(metrics_file, GZIP_READ_TEXT) as f:
+                    metrics = json.load(f)
+                    if metrics:
+                        for key in metrics:
+                            page_data[key] = metrics[key]
+                try:
+                    os.unlink(metrics_file)
+                except Exception:
+                    pass
+        except Exception:
+            logging.exception('Error merging trace page data')
 
     def merge_priority_streams(self):
         """Merge the list of HTTP/2 priority-only stream data"""


### PR DESCRIPTION
This adds some generic framework for adding data from trace events to page_data directly and adds support for pulling the titleTime from the `content` trace events.

The trace events are a bit noisy so they are excluded from the uploaded trace by default (like netlog) unless `content` is explicitly requested as a trace category as part of the test.