### PR TITLE
Backfill sequence numbers for any request missing them

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -823,8 +823,10 @@ class DevTools(object):
         if request_id in self.requests and 'fromNet' in self.requests[request_id] and self.requests[request_id]['fromNet']:
             events = self.requests[request_id]
             request = {'id': request_id}
-            if 'sequence' in events:
-                request['sequence'] = events['sequence']
+            if 'sequence' not in events:
+                self.request_sequence += 1
+                events['sequence'] = self.request_sequence
+            request['sequence'] = events['sequence']
             # See if we have a body
             if include_bodies:
                 body_path = os.path.join(self.task['dir'], 'bodies')
@@ -909,8 +911,6 @@ class DevTools(object):
         # This is only used for optimization checks and custom metrics, not the
         # actual waterfall.
         with self.netlog_lock:
-            # use dummy sequence numbers at the end of the current range
-            sequence = self.request_sequence
             try:
                 path = os.path.join(self.task['dir'], 'netlog_bodies')
                 for netlog_id in self.netlog_requests:
@@ -923,8 +923,8 @@ class DevTools(object):
                             if 'url' in request and request['url'] == url:
                                 found = True
                         if not found:
-                            sequence += 1
-                            request = {'id': netlog_id, 'sequence': sequence, 'url': url}
+                            self.request_sequence += 1
+                            request = {'id': netlog_id, 'sequence': self.request_sequence, 'url': url}
                             if 'request_headers' in netlog_request:
                                 request['request_headers'] = self.extract_headers(netlog_request['request_headers'])
                             if 'response_headers' in netlog_request:

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -487,15 +487,6 @@ class DevtoolsBrowser(object):
             for request_id in raw_requests:
                 self.strip_non_text(raw_requests[request_id])
                 requests.append(raw_requests[request_id])
-            # Make absolutely certain that every request has a sequence number for sorting
-            sequence = 0
-            for request in requests:
-                if 'sequence' in request and request['sequence'] > sequence:
-                    sequence = request['sequence']
-            for request in requests:
-                if 'sequence' not in request:
-                    sequence += 1
-                    request['sequence'] = sequence
             requests = sorted(requests, key=lambda request: request['sequence'])
             requests_json = json.dumps(requests)
         except Exception:

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -487,12 +487,21 @@ class DevtoolsBrowser(object):
             for request_id in raw_requests:
                 self.strip_non_text(raw_requests[request_id])
                 requests.append(raw_requests[request_id])
+            # Make absolutely certain that every request has a sequence number for sorting
+            sequence = 0
+            for request in requests:
+                if 'sequence' in request and request['sequence'] > sequence:
+                    sequence = request['sequence']
+            for request in requests:
+                if 'sequence' not in request:
+                    sequence += 1
+                    request['sequence'] = sequence
             requests = sorted(requests, key=lambda request: request['sequence'])
             requests_json = json.dumps(requests)
         except Exception:
             logging.exception('Error getting json request data')
         if requests_json is None:
-            requests_json = 'null'
+            requests_json = '[]'
         return requests_json
 
     def find_dom_node_info(self, dom_tree, node_id):


### PR DESCRIPTION
There was a previous fix for netlog requests that were missing sequence numbers and it shouldn't be possible for there to be any requests that don't have sequence numbers but there are some reports of some errors with $WPT_REQUESTS still so just to be absolutely positive, this fills in the sequence number for any request that may be missing one (allowing the sort to happen).