### PR TITLE
Fix redirect URL tracking from the netlog

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -363,6 +363,7 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
                     self.netlog.on_request_headers_sent = self.devtools.on_netlog_request_headers_sent           # (request_id, request_headers)
                     self.netlog.on_response_headers_received = self.devtools.on_netlog_response_headers_received # (request_id, response_headers)
                     self.netlog.on_response_bytes_received = self.devtools.on_netlog_response_bytes_received     # (request_id, filtered_bytes)
+                    self.netlog.on_request_id_changed = self.devtools.on_request_id_changed                      # (request_id, new_request_id)
 
                 if self.netlog_header:
                     for line in self.netlog_header:

--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -1860,6 +1860,18 @@ class DevTools(object):
         except Exception:
             logging.exception('Error handling on_netlog_response_bytes_received')
 
+    def on_request_id_changed(self, request_id, new_request_id):
+        """Callbacks from streamed netlog processing (these will come in on a background thread)"""
+        try:
+            with self.netlog_lock:
+                if request_id in self.netlog_requests and new_request_id not in self.netlog_requests:
+                    self.netlog_requests[new_request_id] = self.netlog_requests[request_id]
+                    del self.netlog_requests[request_id]
+            logging.debug("Netlog request ID changed from %s to %s", request_id, new_request_id)
+        except Exception:
+            logging.exception('Error handling on_request_id_changed')
+
+
 class DevToolsClient(WebSocketClient):
     """DevTools WebSocket client"""
     def __init__(self, url, protocols=None, extensions=None, heartbeat_freq=None,


### PR DESCRIPTION
This fixes an issue where redirects were sometimes picking up incorrect data (URL and headers) from the final request instead of just the redirect response.

Not sure when/how this broke because it used to work for sure.

[Sample test](https://wpt.meenan.us/result/220930_RQ_1/1/details/#waterfall_view_step1) (See request #26 which is now correct)
Fixes https://github.com/WPO-Foundation/wptagent/issues/573