### PR TITLE
Sanitize user-supplied command-line params

### DIFF
--- a/internal/base_browser.py
+++ b/internal/base_browser.py
@@ -4,12 +4,11 @@
 # Use of this source code is governed by the Polyform Shield 1.0.0 license that can be
 # found in the LICENSE.md file.
 """Base class support for browsers"""
+import logging
 import os
-import sys
-if (sys.version_info >= (3, 0)):
-    from time import monotonic
-else:
-    from monotonic import monotonic
+import platform
+import shlex
+from time import monotonic
 
 class BaseBrowser(object):
     """Browser base"""
@@ -37,3 +36,25 @@ class BaseBrowser(object):
     def shutdown(self):
         """Agent is dying, close as much as possible gracefully"""
         self.must_exit = True
+
+    def sanitize_shell_args(self, args):
+        """Sanitize a list of arguments that will be used in a shell subprocess"""
+        try:
+            if platform.system() in ["Linux", "Darwin"]:
+                args = [shlex.quote(arg) for arg in args]
+        except Exception:
+            logging.exception('Error sanitizing shell args')
+
+    def sanitize_shell_string(self, shell_string):
+        """Sanitize a string of arguments that will be used in a shell subprocess"""
+        sanitized_string = ''
+        try:
+            if platform.system() in ["Linux", "Darwin"]:
+                args = shlex.split(shell_string)
+                args = [shlex.quote(arg) for arg in args]
+                sanitized_string = ' '.join(args)
+            else:
+                sanitized_string = shell_string
+        except Exception:
+            logging.exception('Error sanitizing shell string')
+        return sanitized_string

--- a/internal/blackbox_android.py
+++ b/internal/blackbox_android.py
@@ -84,9 +84,10 @@ class BlackBoxAndroid(AndroidBrowser):
         args.append('--host-resolver-rules=' + ','.join(host_rules))
         if 'ignoreSSL' in job and job['ignoreSSL']:
             args.append('--ignore-certificate-errors')
+        self.sanitize_shell_args(args)
         command_line = 'chrome ' + ' '.join(args)
         if 'addCmdLine' in job:
-            command_line += ' ' + job['addCmdLine']
+            command_line += ' ' + self.sanitize_shell_string(job['addCmdLine'])
         local_command_line = os.path.join(task['dir'], 'chrome-command-line')
         remote_command_line = '/data/local/tmp/chrome-command-line'
         root_command_line = '/data/local/chrome-command-line'

--- a/internal/chrome_android.py
+++ b/internal/chrome_android.py
@@ -156,9 +156,10 @@ class ChromeAndroid(AndroidBrowser, DevtoolsBrowser):
         args.append('--enable-features=' + ','.join(features))
         args.append('--enable-blink-features=' + ','.join(ENABLE_BLINK_FEATURES))
         args.append('--disable-features=' + ','.join(disable_features))
+        self.sanitize_shell_args(args)
         command_line = 'chrome ' + ' '.join(args)
         if 'addCmdLine' in job:
-            command_line += ' ' + job['addCmdLine']
+            command_line += ' ' + self.sanitize_shell_string(job['addCmdLine'])
         command_line += ' about:blank'
         local_command_line = os.path.join(task['dir'], self.config['command_line_file'])
         remote_command_line = '/data/local/tmp/' + self.config['command_line_file']

--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -179,9 +179,10 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
             command_line = '"{0}"'.format(self.path)
         else:
             command_line = self.path
+        self.sanitize_shell_args(args)
         command_line += ' ' + ' '.join(args)
         if 'addCmdLine' in job:
-            command_line += ' ' + job['addCmdLine']
+            command_line += ' ' + self.sanitize_shell_string(job['addCmdLine'])
         command_line += ' ' + 'about:blank'
         # re-try launching and connecting a few times if necessary
         connected = False

--- a/internal/os_util.py
+++ b/internal/os_util.py
@@ -87,6 +87,14 @@ def run_elevated(command, args, wait=True):
             else:
                 ret = process_info
         else:
+            try:
+                import shlex
+                if platform.system() in ["Linux", "Darwin"]:
+                    params = shlex.split(args)
+                    params = [shlex.quote(arg) for arg in params]
+                    args = ' '.join(params)
+            except Exception:
+                logging.exception('Error sanitizing elevated shell string')
             logging.debug('sudo ' + command + ' ' + args)
             ret = subprocess.call('sudo ' + command + ' ' + args, shell=True)
     except Exception:


### PR DESCRIPTION
In case something sneaks through the server-side sanitization, this sanitizes/quotes the command-line params when using the shell, particularly the browser ones that support user-provided params.