### PR TITLE
Disable the Chrome fetch of autofill information.

### DIFF
--- a/internal/chrome_android.py
+++ b/internal/chrome_android.py
@@ -58,7 +58,8 @@ DISABLE_CHROME_FEATURES = [
     'CalculateNativeWinOcclusion',
     'TranslateUI',
     'Translate',
-    'OfflinePagesPrefetching'
+    'OfflinePagesPrefetching',
+    'AutofillServerCommunication'
 ]
 
 ENABLE_CHROME_FEATURES = [

--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -67,7 +67,8 @@ DISABLE_CHROME_FEATURES = [
     'TranslateUI',
     'Translate',
     'OfflinePagesPrefetching',
-    'HeavyAdPrivacyMitigations'
+    'HeavyAdPrivacyMitigations',
+    'AutofillServerCommunication'
 ]
 
 ENABLE_BLINK_FEATURES = [


### PR DESCRIPTION
This should get rid of the unexpected requests reported in the [forums](https://forums.webpagetest.org/t/unexpected-http-call-content-autofill-googleapis/13036) but, if not, the actual origins will need to be added to the block list as well (didn't add them now to keep the command-line from getting too big unnecessarily).