### PR TITLE
Allow for running a script in an arbitrary frame context

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -689,9 +689,16 @@ class DevtoolsBrowser(object):
                 needs_mark = True
                 if self.task['combine_steps']:
                     needs_mark = False
-                script = self.prepare_script_for_record(script, needs_mark) #pylint: disable=no-member
+                if self.devtools.execution_context is not None:
+                    # Clear the orange frame as a separate step to make sure it is done in the correct context
+                    clear_script = self.prepare_script_for_record('', needs_mark)
+                    self.devtools.execute_js(clear_script)
+                else:
+                    script = self.prepare_script_for_record(script, needs_mark) #pylint: disable=no-member
                 self.devtools.start_navigating()
-            self.devtools.execute_js(script)
+            self.devtools.execute_js(script, True)
+        elif command['command'] == 'setexecutioncontext':
+            self.devtools.set_execution_context(command['target'])
         elif command['command'] == 'sleep':
             available_sleep = 60 - self.total_sleep
             delay = min(available_sleep, max(0, int(re.search(r'\d+', str(command['target'])).group())))


### PR DESCRIPTION
This enables cross-origin frame scripting for Chromium browsers (might work on iOS as well, haven't tested there yet).

It collects the available execution contexts from Chromium browsers and adds it to the page data json as execution_contexts:

```json
"execution_contexts": [
    {
        "id": 2,
        "origin": "http:\/\/127.0.0.1:8888",
        "name": ""
    },
    {
        "id": 3,
        "origin": "https:\/\/codepen.io",
        "name": ""
    },
    {
        "id": 4,
        "origin": "https:\/\/cdpn.io",
        "name": ""
    }
],
```

It also adds a new script command, `setExecutionContext` that lets you match one of the available contexts by id, origin or name (though name is always blank as best as I can tell) and any future exec commands will target that context (and it can be reset to the main document by not passing a match).

```
navigate	https://codepen.io/juno_okyo/pen/yOjaEZ
setExecutionContext	origin=https://cdpn.io
execAndWait	document.getElementById('name-input').value = 'Bob'; fetch('https://cdpn.io/blank.html');
```