### PR TITLE
Fixed netlog url generation from headers.

### DIFF
--- a/internal/support/netlog.py
+++ b/internal/support/netlog.py
@@ -178,13 +178,13 @@ class Netlog():
                                 key = header[:index].strip(u': ').lower()
                                 value = header[index + 1:].strip(u': ')
                                 if key == u'scheme':
-                                    scheme = unicode(value)
+                                    scheme = str(value)
                                 elif key == u'host':
-                                    origin = unicode(value)
+                                    origin = str(value)
                                 elif key == u'authority':
-                                    origin = unicode(value)
+                                    origin = str(value)
                                 elif key == u'path':
-                                    path = unicode(value)
+                                    path = str(value)
                         except Exception:
                             logging.exception("Error generating url from request headers")
                     if scheme and origin and path:


### PR DESCRIPTION
Other parts of the code define "unicode" as str for python3 (for 2/3 interop) but this file was created after the switch to python3 so the 2/3 interop definitions were never added but the "unicode" operator was still trying to be used (copied from the trace netlog processing)