### PR TITLE
Stop disabling BF Cache for Chrome

### DIFF
--- a/internal/chrome_android.py
+++ b/internal/chrome_android.py
@@ -59,7 +59,6 @@ HOST_RULES = [
 
 DISABLE_CHROME_FEATURES = [
     'AutofillServerCommunication',
-    'BackForwardCache',
     'CalculateNativeWinOcclusion',
     'HeavyAdPrivacyMitigations',
     'InterestFeedContentSuggestions',

--- a/internal/chrome_android.py
+++ b/internal/chrome_android.py
@@ -59,6 +59,7 @@ HOST_RULES = [
 
 DISABLE_CHROME_FEATURES = [
     'AutofillServerCommunication',
+    'BackForwardCache',
     'CalculateNativeWinOcclusion',
     'HeavyAdPrivacyMitigations',
     'InterestFeedContentSuggestions',

--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -62,6 +62,7 @@ ENABLE_CHROME_FEATURES = [
 
 DISABLE_CHROME_FEATURES = [
     'AutofillServerCommunication',
+    'BackForwardCache',
     'CalculateNativeWinOcclusion',
     'HeavyAdPrivacyMitigations',
     'InterestFeedContentSuggestions',

--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -62,7 +62,6 @@ ENABLE_CHROME_FEATURES = [
 
 DISABLE_CHROME_FEATURES = [
     'AutofillServerCommunication',
-    'BackForwardCache',
     'CalculateNativeWinOcclusion',
     'HeavyAdPrivacyMitigations',
     'InterestFeedContentSuggestions',


### PR DESCRIPTION
Originally there was some concern that the feature would cause problem for multi-step navigations since it keeps the old renderer around but it ends up to not be an issue: https://wpt.meenan.us/result/221205_ZiC4_2/

Leaving BF Cache enabled will make sure to test multi-step navigations like real visitors, including any background activity that isn't silenced immediately for more accurate results (it also allows for testing the improvements for back navigations).