### PR TITLE
Improve traffic-shaping compatibility

### DIFF
--- a/internal/traffic_shaping.py
+++ b/internal/traffic_shaping.py
@@ -566,6 +566,12 @@ class NetEm(object):
                                      'ffff:', 'protocol', 'ip', 'u32', 'match', 'u32', '0', '0',
                                      'flowid', '1:1', 'action', 'mirred', 'egress', 'redirect',
                                      'dev', 'ifb0'])
+                # Turn off tcp offload acceleration on the interfaces
+                try:
+                    subprocess.call(['sudo', 'ethtool', '-K', self.interface, 'tso', 'off', 'gso', 'off', 'gro', 'off'])
+                    subprocess.call(['sudo', 'ethtool', '-K', self.in_interface, 'tso', 'off', 'gso', 'off', 'gro', 'off'])
+                except Exception:
+                    logging.exception('Error disabling tso on interfaces for traffic shaping')
                 self.reset()
                 ret = True
             else:

--- a/ubuntu_install.sh
+++ b/ubuntu_install.sh
@@ -17,7 +17,7 @@ curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 
 # Install all of the binary dependencies
 echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-until sudo apt -y install git curl wget apt-transport-https gnupg2 python python3 python3-pip python3-ujson \
+until sudo apt -y install git curl wget apt-transport-https gnupg2 python3 python3-pip python3-ujson \
         imagemagick dbus-x11 traceroute software-properties-common psmisc libnss3-tools iproute2 net-tools openvpn \
         libtiff5-dev libjpeg-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
         python3-dev libavutil-dev libmp3lame-dev libx264-dev yasm autoconf automake build-essential libass-dev libfreetype6-dev libtheora-dev \


### PR DESCRIPTION
Not a critical change since I don't believe any of the VM environment use the hardware acceleration offloads but discovered this one when I was working on the Ubuntu 22.04 support.  This turns off the TCP offload features that can cause packets to bypass traffic shaping for systems that support hardware offload.  It's a no-op for other systems but doesn't hurt.

Everything else in the agent worked fine out-of-the-box on 22.04 (technically this did as well)