### PR TITLE
Fix json encoding of testinfo for Ubuntu 22.04

### DIFF
--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -1420,7 +1420,7 @@ class WebPageTest(object):
                     self.job['testinfo']['steps'] = max_steps
                 json_path = os.path.join(self.workdir, 'testinfo.json')
                 with open(json_path, 'wt') as f_out:
-                    json.dump(self.job['testinfo'], f_out)
+                    json.dump(self.job['testinfo'], f_out, default=lambda o: '')
                 self.needs_zip.append({'path': json_path, 'name': 'testinfo.json'})
 
             # Zip the files


### PR DESCRIPTION
More likely than not, the behavior changed in a python revision between 3.4 and whatever is currently running on ubuntu 22.04 but the 'testinfo' dictionary entry containes a few live objects when it is cloned from the current job (TrafficShaper and MessageServer).  Previously it would just skip encoding those fields and continue.

This change makes it explicit and interprets and objects that can't be serialized to json as an empty string.

This fixes the agents running on Ubuntu 22.04 when the work they are doing is not generated from the WPT UI and they are synthesizing the test info (i.e. in the HTTP Archive or other batch modes).

Verified that this fixes the issue with using Ubuntu 22.04 for the HTTP Archive agents.