### PR TITLE
github actions fix, ubuntu-18.04 set

### DIFF
--- a/.github/workflows/wptagent_test.yml
+++ b/.github/workflows/wptagent_test.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/wptagent_test.yml
+++ b/.github/workflows/wptagent_test.yml
@@ -5,9 +5,9 @@ name: Python application
 
 on:
   push:
-    branches: [ master, MoreActions]
+    branches: [ master, patch-2]
   pull_request:
-    branches: [ master, MoreActions]
+    branches: [ master, patch-2]
 
 permissions:
   contents: read


### PR DESCRIPTION
Issue with ubuntu-latest being updated and 3.6.8 python versionbeing no longer supported for github actions. changed ubuntu-latest to ubuntu-18.04.

Athough ubuntu-18.04 environment is now deprecated so we should consider updating.
https://github.com/actions/runner-images
https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json python version manifest