### PR TITLE
Treat page load timeouts as soft errors

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -200,6 +200,7 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
                 DesktopBrowser.stop(self, job, task)
                 if 'error' in task and task['error'] is not None:
                     task['error'] = None
+                    task['soft_error'] = False
                 # try launching the browser with no command-line options to
                 # do any one-time startup initialization
                 if count == 1:

--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -837,7 +837,7 @@ class DevTools(object):
             return
         self.profile_start('get_response_bodies')
         requests = self.get_requests(True)
-        if self.task['error'] is None and requests:
+        if (self.task['error'] is None or self.task['soft_error']) and requests:
             for request_id in requests:
                 self.get_response_body(request_id, True)
         self.profile_end('get_response_bodies')
@@ -1111,12 +1111,14 @@ class DevTools(object):
                     # only consider it an error if we didn't get a page load event
                     if self.page_loaded is None:
                         self.task['error'] = "Page Load Timeout"
+                        self.task['soft_error'] = True
                         self.task['page_data']['result'] = 99997
                 elif max_requests > 0 and self.request_count > max_requests:
                     done = True
                     # only consider it an error if we didn't get a page load event
                     if self.page_loaded is None:
                         self.task['error'] = "Exceeded Maximum Requests"
+                        self.task['soft_error'] = True
                         self.task['page_data']['result'] = 99997
                 elif self.wait_for_script is not None:
                     elapsed_interval = now - last_wait_interval
@@ -1204,7 +1206,7 @@ class DevTools(object):
         if self.must_exit:
             return
         ret = None
-        if self.task['error'] is None and not self.main_thread_blocked:
+        if (self.task['error'] is None or self.task['soft_error']) and not self.main_thread_blocked:
             if self.is_webkit:
                 response = self.send_command('Runtime.evaluate', {'expression': script, 'returnByValue': True}, timeout=30, wait=True)
             else:

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -82,7 +82,7 @@ class DevtoolsBrowser(object):
         if self.devtools is not None:
             # Always navigate to about:blank after finishing in case the tab is
             # remembered across sessions
-            if self.task is not None and self.task['error'] is None:
+            if self.task is not None and (self.task['error'] is None or self.task['soft_error']):
                 self.devtools.send_command('Page.navigate', {'url': 'about:blank'}, wait=True)
             if self.webkit_context is not None:
                 self.devtools.send_command('Automation.closeBrowsingContext', {'handle': self.webkit_context}, wait=True)

--- a/internal/firefox.py
+++ b/internal/firefox.py
@@ -469,12 +469,14 @@ class Firefox(DesktopBrowser):
                     # only consider it an error if we didn't get a page load event
                     if self.page_loaded is None:
                         self.task['error'] = "Page Load Timeout"
+                        self.task['soft_error'] = True
                         self.task['page_data']['result'] = 99998
                 elif max_requests > 0 and self.request_count > max_requests:
                     done = True
                     # only consider it an error if we didn't get a page load event
                     if self.page_loaded is None:
                         self.task['error'] = "Exceeded Maximum Requests"
+                        self.task['soft_error'] = True
                         self.task['page_data']['result'] = 99997
                 elif self.wait_for_script is not None:
                     elapsed_interval = now - last_wait_interval

--- a/internal/microsoft_edge.py
+++ b/internal/microsoft_edge.py
@@ -364,12 +364,14 @@ class Edge(DesktopBrowser):
                     # only consider it an error if we didn't get a page load event
                     if self.page_loaded is None:
                         self.task['error'] = "Page Load Timeout"
+                        self.task['soft_error'] = True
                         self.task['page_data']['result'] = 99998
                 elif max_requests > 0 and self.request_count > max_requests:
                     done = True
                     # only consider it an error if we didn't get a page load event
                     if self.page_loaded is None:
                         self.task['error'] = "Exceeded Maximum Requests"
+                        self.task['soft_error'] = True
                         self.task['page_data']['result'] = 99997
                 elif self.wait_for_script is not None:
                     elapsed_interval = now - last_wait_interval

--- a/internal/safari_desktop.py
+++ b/internal/safari_desktop.py
@@ -261,12 +261,14 @@ class SafariDesktop(DesktopBrowser):
                     # only consider it an error if we didn't get a page load event
                     if self.page_loaded is None:
                         self.task['error'] = "Page Load Timeout"
+                        self.task['soft_error'] = True
                         self.task['page_data']['result'] = 99998
                 elif max_requests > 0 and self.request_count > max_requests:
                     done = True
                     # only consider it an error if we didn't get a page load event
                     if self.page_loaded is None:
                         self.task['error'] = "Exceeded Maximum Requests"
+                        self.task['soft_error'] = True
                         self.task['page_data']['result'] = 99997
                 elif self.wait_for_script is not None:
                     elapsed_interval = now - last_wait_interval

--- a/internal/safari_ios.py
+++ b/internal/safari_ios.py
@@ -290,11 +290,13 @@ class iWptBrowser(BaseBrowser):
                     # only consider it an error if we didn't get a page load event
                     if self.page_loaded is None:
                         self.task['error'] = "Page Load Timeout"
+                        self.task['soft_error'] = True
                 elif max_requests > 0 and self.request_count > max_requests:
                     done = True
                     # only consider it an error if we didn't get a page load event
                     if self.page_loaded is None:
                         self.task['error'] = "Exceeded Maximum Requests"
+                        self.task['soft_error'] = True
                         self.task['page_data']['result'] = 99997
                 elif self.wait_for_script is not None:
                     elapsed_interval = now - last_wait_interval

--- a/internal/webpagetest.py
+++ b/internal/webpagetest.py
@@ -811,6 +811,7 @@ class WebPageTest(object):
                         'done': False,
                         'profile': profile_dir,
                         'error': None,
+                        'soft_error': False,
                         'log_data': True,
                         'activity_time': 3,
                         'combine_steps': False,

--- a/wptagent.py
+++ b/wptagent.py
@@ -267,7 +267,7 @@ class WPTAgent(object):
                             self.wpt.get_bodies(self.task)
                         if self.task['run'] == 1 and not self.task['cached'] and \
                                 self.job['warmup'] <= 0 and \
-                                self.task['error'] is None and \
+                                (self.task['error'] is None or self.task['soft_error']) and \
                                 'lighthouse' in self.job and self.job['lighthouse']:
                             if 'page_result' not in self.task or \
                                     self.task['page_result'] is None or \


### PR DESCRIPTION
This allows for collecting metrics and running lighthouse audits on pages where the onload didn't fire before the timeout but otherwise is still working.

Otherwise, all JS execution (in chrome) is bypassed as soon as a test is in an error state.

Fixes https://github.com/HTTPArchive/custom-metrics/issues/63