### PR TITLE
Remove the Origin header from websocket connections

### DIFF
--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -264,19 +264,6 @@ class WebSocketBaseClient(WebSocket):
         if self.extra_headers:
             headers.extend(self.extra_headers)
 
-        if not any(x for x in headers if x[0].lower() == 'origin'):
-
-            scheme, url = self.url.split(":", 1)
-            parsed = urlsplit(url, scheme="http")
-            if parsed.hostname:
-                self.host = parsed.hostname
-            else:
-                self.host = 'localhost'
-            origin = scheme + '://' + self.host
-            if parsed.port:
-                origin = origin + ':' + str(parsed.port)
-            headers.append(('Origin', origin))
-
         return headers
 
     @property


### PR DESCRIPTION
It's a header meant to be used with browsers and breaks connecting to dev tools in Chrome 111

https://chromium-review.googlesource.com/c/chromium/src/+/4106102