### PR TITLE
Fix support for Lighthouse 10

### DIFF
--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -836,6 +836,7 @@ class DevtoolsBrowser(object):
                        '"{0}"'.format(self.job['url']),
                        '--channel', 'wpt',
                        '--enable-error-reporting',
+                       '--legacy-navigation',
                        '--max-wait-for-load', str(int(time_limit * 1000)),
                        '--port', str(task['port']),
                        '--output', 'html',

--- a/wptagent.py
+++ b/wptagent.py
@@ -572,16 +572,16 @@ class WPTAgent(object):
             except Exception:
                 pass
 
-        # Check for Node 14+
-        if self.get_node_version() < 14.0:
+        # Check for Node 16+
+        if self.get_node_version() < 16.0:
             if platform.system() == "Linux":
                 # This only works on debian-based systems
-                logging.debug('Updating Node.js to 14.x')
+                logging.debug('Updating Node.js to 16.x')
                 subprocess.call('sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates', shell=True)
-                subprocess.call('curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash -', shell=True)
+                subprocess.call('curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -', shell=True)
                 subprocess.call(['sudo', 'apt-get', 'install', '-y', 'nodejs'])
-            if self.get_node_version() < 12.0:
-                logging.warning("Node.js 12 or newer is required for Lighthouse testing")
+            if self.get_node_version() < 16.0:
+                logging.warning("Node.js 16 or newer is required for Lighthouse testing")
 
         # Check the iOS install
         if self.ios is not None:


### PR DESCRIPTION
* Opt into the legacy navigation flow. Lighthouse fails to end the test otherwise.
* Require Node 16 minimum (and auto-install it on ubuntu)

Verified that lighthouse@next works with these changes.