### PR TITLE
Fix dns timing in all_start and all_end

### DIFF
--- a/internal/process_test.py
+++ b/internal/process_test.py
@@ -867,7 +867,7 @@ class ProcessTest(object):
                         start = req[start_key] if start_key in req else 0
                         end = req[end_key] if end_key in req else 0
                         ms = req[ms_key] if ms_key in req else 0
-                        if end > 0 and start > 0 and end >= start:
+                        if end > 0 and start >= 0 and end >= start:
                             ms = end - start
                         if ms > 0:
                             if start == 0:


### PR DESCRIPTION
When we were calculating the start time for a request, we were checking to see if start > 0. That meant that on the initial request, if the start time was 0 exactly, we were incorrectly calculating the all_start and all_end times, effectively leaving the DNS timings out.

This fixes that by checking if >= 0 instead.