### PR TITLE
Use Chrome's new headless mode for lighthouse

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -148,7 +148,7 @@ class ChromeDesktop(DesktopBrowser, DevtoolsBrowser):
         if len(ENABLE_BLINK_FEATURES):
             args.append('--enable-blink-features=' + ','.join(ENABLE_BLINK_FEATURES))
         if task['running_lighthouse']:
-            args.append('--headless')
+            args.append('--headless=new')
         
         if 'extensions' in job:
             extensions = job['extensions'].split(',')

--- a/internal/devtools_browser.py
+++ b/internal/devtools_browser.py
@@ -836,7 +836,6 @@ class DevtoolsBrowser(object):
                        '"{0}"'.format(self.job['url']),
                        '--channel', 'wpt',
                        '--enable-error-reporting',
-                       '--legacy-navigation',
                        '--disable-full-page-screenshot',
                        '--max-wait-for-load', str(int(time_limit * 1000)),
                        '--hostname', '127.0.0.1',


### PR DESCRIPTION
This is a clean re-submit of https://github.com/WPO-Foundation/wptagent/pull/605

Chrome has a ["new" headless mode](https://www.selenium.dev/blog/2023/headless-is-going-away/#what-are-the-two-headless-modes) in 109+ (technically added in 96 but it's the official way now) that makes headless Chrome behave much more like the real Chrome with UI and uses all of the same code. Of particular note for WebPageTest is that this makes the lighthouse audits (where headless is used) more accurate and fixes issues with the BF cache audit.

Chrome 112 (which is when the feature is officially GA) just rolled to stable.  We have been using the new setting in the HTTP Archive for the past few months and highly recommend picking it up.