### PR TITLE
Fix resetting of execution context

### DIFF
--- a/internal/devtools.py
+++ b/internal/devtools.py
@@ -1239,7 +1239,7 @@ class DevTools(object):
 
     def set_execution_context(self, target):
         """ Set the js execution context by matching id, origin or name """
-        if len(target):
+        if target is not None and len(target):
             parts = target.split('=', 1)
             if len(parts) == 2:
                 key = parts[0].strip()


### PR DESCRIPTION
`setExecutionContext` with no context is supposed to reset it but was throwing an exception because the target param is `None` when missing.

For #616