### PR TITLE
Flush DNS cache on ubuntu 22.04+

### DIFF
--- a/internal/os_util.py
+++ b/internal/os_util.py
@@ -60,6 +60,7 @@ def flush_dns():
         subprocess.call(['sudo', 'service', 'dnsmasq', 'restart'])
         subprocess.call(['sudo', 'rndc', 'restart'])
         subprocess.call(['sudo', 'systemd-resolve', '--flush-caches'])
+        subprocess.call(['sudo', 'resolvectl', 'flush-caches'])
 
 # pylint: disable=E0611,E0401
 def run_elevated(command, args, wait=True):


### PR DESCRIPTION
Looks like there's yet another way.  See: https://askubuntu.com/questions/1404586/how-to-clear-dns-cache-in-22-04