### PR TITLE
Get rid of the tooltip promoting the side panel

### DIFF
--- a/internal/chrome_desktop.py
+++ b/internal/chrome_desktop.py
@@ -68,6 +68,7 @@ DISABLE_CHROME_FEATURES = [
     'MediaRouter',
     'OfflinePagesPrefetching',
     'OptimizationHints',
+    'SidePanelPinning',
     'Translate',
     # Disable noisy Edge features
     'msAutofillEdgeCoupons',


### PR DESCRIPTION
This gets rid of the blue tooltip in the top-right corner of the screen that has started showing up in Chrome results.

Examples of [before](https://webpagetest.httparchive.org/video/compare.php?tests=240519_P2_6-r:1-c:0) and [after](https://webpagetest.httparchive.org/video/compare.php?tests=240519_7T_5-r:1-c:0) showing the tooltip artificially triggering start render.